### PR TITLE
tests: isolate loader tests and use schema validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ Saveoifits/
 TestSPHEREData/
 
 # Install files 
-*.txt
 PKG*
 my*.py
 

--- a/amical/tests/test_io.py
+++ b/amical/tests/test_io.py
@@ -6,7 +6,6 @@ import pytest
 from astropy.io import fits
 
 import amical
-from amical import load, loadc
 from amical.get_infos_obs import get_pixel_size
 
 TEST_DIR = Path(__file__).parent
@@ -16,12 +15,6 @@ example_fits = TEST_DATA_DIR / "test.fits"
 save_v2_gauss = TEST_DATA_DIR / 'save_results_v2_example_gauss.fits'
 save_cp_gauss = TEST_DATA_DIR / 'save_results_cp_example_gauss.fits'
 save_cp_fft = TEST_DATA_DIR / 'save_results_cp_example_fft.fits'
-
-
-@pytest.mark.parametrize("filepath", [example_oifits])
-def test_load_file(filepath):
-    s = load(filepath)
-    assert isinstance(s, dict)
 
 
 @pytest.mark.parametrize("filepath", [example_fits])
@@ -174,11 +167,6 @@ def test_pymask(filepath):
     fit2 = amical.pymask_grid([filepath])
     assert isinstance(fit2, dict)
 
-
-@pytest.mark.parametrize("filepath", [example_oifits])
-def test_loadc_file(filepath):
-    s = loadc(filepath)
-    assert isinstance(s, munch.Munch)
 
 
 @pytest.mark.parametrize("ins", ['NIRISS', 'SPHERE', 'VAMPIRES'])

--- a/amical/tests/test_load.py
+++ b/amical/tests/test_load.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import pytest
+from schema import Schema
+from numpy import ndarray
+from amical import load, loadc
+
+TEST_DIR = Path(__file__).parent
+TEST_DATA_DIR = TEST_DIR / "data"
+example_oifits = TEST_DATA_DIR / "test.oifits"
+
+schema = Schema(
+    {
+        "target": str,
+        "calib": str,
+        "seeing": float,
+        "mjd": float,
+        "wl": ndarray,
+        "e_wl": ndarray,
+        "vis2": ndarray,
+        "e_vis2": ndarray,
+        "u": ndarray,
+        "v": ndarray,
+        "bl": ndarray,
+        "flag_vis": ndarray,
+        "cp": ndarray,
+        "e_cp": ndarray,
+        "u1": ndarray,
+        "v1": ndarray,
+        "u2": ndarray,
+        "v2": ndarray,
+        "bl_cp": ndarray,
+        "flag_cp": ndarray,
+    }
+)
+
+@pytest.mark.parametrize("load_fun", [load, loadc])
+def test_load(load_fun):
+    data = load_fun(example_oifits)
+    schema.validate(data)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,2 @@
+pytest
+schema


### PR DESCRIPTION
Here I'm trying to provide better tests for `amical.load` and `amical.loadc` with schema validation of their respective outputs against a common data file.
I wrote the validation schema following the current result of `loadc` and I acknowledge that the result from `load` is inconsistent. I don't know wether this is expected or not but it looks like a bug from afar. @DrSoulain, is this supposed to be so ?