### PR TITLE
Handle missing file in candid Open

### DIFF
--- a/amical/externals/candid/candid.py
+++ b/amical/externals/candid/candid.py
@@ -1146,6 +1146,8 @@ class Open:
             self._loadOifitsData(filename, reducePoly=reducePoly, largeCP=largeCP,
                                  err_scale=err_scale, extra_error=extra_error,
                                  extra_error_v2=extra_error_v2)
+        else:
+            raise FileNotFoundError(f"filename {filename} is not a valid file or directory")
 
         if verbose:
             print(' | compute aux data for companion injection')


### PR DESCRIPTION
Small addition to the `candid.Open` init method to raise an explicit error when the `filename` argument is not an existing file or directory. It makes it clearer for users if the oifits files are not found on disk, instead of raising an `AttributeError` error only when the data is accessed by candid later, as pointed out in #22.