### PR TITLE
Temporary fix for astropy _HeaderCommentaryCards

### DIFF
--- a/amical/mf_pipeline/bispect.py
+++ b/amical/mf_pipeline/bispect.py
@@ -1000,6 +1000,9 @@ def _add_infos_header(infos, hdr, mf, pa, filename, maskname, npix):
     for key in hdr_commentary_keys:
         hdr.remove(key, ignore_missing=True, remove_all=True)
 
+    # Now that header is compatible with munc, we add it to infos
+    infos["hdr"] = hdr
+
     # Save keys of the original header (as needed):
     add_keys = ["TELESCOP", "DATE-OBS", "MJD-OBS", "OBSERVER"]
     if infos.orig != "SimulatedData":

--- a/amical/mf_pipeline/bispect.py
+++ b/amical/mf_pipeline/bispect.py
@@ -992,6 +992,7 @@ def _add_infos_header(infos, hdr, mf, pa, filename, maskname, npix):
     # HACK: astropy _HeaderCommentaryCards are registered as mappings,
     # so munch tries to access their keys, leading to attribute error
     # to prevent this, we remove commentary cards as a temporary fix.
+    # (As of June 23 2021, with astropy version 4.2.1)
     # See:
     # https://github.com/SydneyAstrophotonicInstrumentationLab/AMICAL/issues/31
     # https://github.com/astropy/astropy/issues/11866
@@ -1000,7 +1001,7 @@ def _add_infos_header(infos, hdr, mf, pa, filename, maskname, npix):
     for key in hdr_commentary_keys:
         hdr.remove(key, ignore_missing=True, remove_all=True)
 
-    # Now that header is compatible with munc, we add it to infos
+    # Now that header is compatible with munch, we add it to infos
     infos["hdr"] = hdr
 
     # Save keys of the original header (as needed):

--- a/amical/mf_pipeline/bispect.py
+++ b/amical/mf_pipeline/bispect.py
@@ -988,6 +988,19 @@ def _add_infos_header(infos, hdr, mf, pa, filename, maskname, npix):
     infos["filename"] = filename
     infos["maskname"] = maskname
     infos["isz"] = npix
+
+    # HACK: astropy _HeaderCommentaryCards are registered as mappings,
+    # so munch tries to access their keys, leading to attribute error
+    # to prevent this, we remove commentary cards as a temporary fix.
+    # See:
+    # https://github.com/SydneyAstrophotonicInstrumentationLab/AMICAL/issues/31
+    # https://github.com/astropy/astropy/issues/11866
+    hdr_commentary_keys = fits.Card._commentary_keywords
+    hdr = hdr.copy()
+    for key in hdr_commentary_keys:
+        hdr.remove(key, ignore_missing=True, remove_all=True)
+
+    # NOTE: Not sure this is needed with the above fix
     if "SPHERE" not in infos.instrument:
         infos["hdr"] = hdr
 

--- a/amical/mf_pipeline/bispect.py
+++ b/amical/mf_pipeline/bispect.py
@@ -1000,10 +1000,6 @@ def _add_infos_header(infos, hdr, mf, pa, filename, maskname, npix):
     for key in hdr_commentary_keys:
         hdr.remove(key, ignore_missing=True, remove_all=True)
 
-    # NOTE: Not sure this is needed with the above fix
-    if "SPHERE" not in infos.instrument:
-        infos["hdr"] = hdr
-
     # Save keys of the original header (as needed):
     add_keys = ["TELESCOP", "DATE-OBS", "MJD-OBS", "OBSERVER"]
     if infos.orig != "SimulatedData":

--- a/amical/tests/test_extraction.py
+++ b/amical/tests/test_extraction.py
@@ -1,0 +1,23 @@
+import munch
+from munch import munchify as dict2class
+from astropy.io import fits
+
+from amical.mf_pipeline.bispect import _add_infos_header
+
+
+def test_add_infos_header_commentary():
+    # Make sure that _add_infos_header handles _HeaderCommentaryCards from astropy
+
+    # Create a fits header with commentary card
+    hdr = fits.Header()
+    hdr["HISTORY"] = "History is a commentary card"
+
+    # SimulatedData avoids requiring extra keys in infos
+    infos = munch.Munch(orig="SimulatedData", instrument="unknown")
+
+    # Add hdr to infos laceholders for everything but hdr
+    mf = munch.Munch(pixelSize=1.0)
+    infos = _add_infos_header(infos, hdr, mf, 1.0, "afilename", "amaskname", 1)
+
+    # Convert everything to munch object
+    dict2class(infos)

--- a/amical/tests/test_extraction.py
+++ b/amical/tests/test_extraction.py
@@ -1,5 +1,4 @@
 import munch
-from munch import munchify as dict2class
 from astropy.io import fits
 
 from amical.mf_pipeline.bispect import _add_infos_header
@@ -20,4 +19,4 @@ def test_add_infos_header_commentary():
     infos = _add_infos_header(infos, hdr, mf, 1.0, "afilename", "amaskname", 1)
 
     # Convert everything to munch object
-    dict2class(infos)
+    munch.munchify(infos)

--- a/amical/tests/test_extraction.py
+++ b/amical/tests/test_extraction.py
@@ -15,7 +15,7 @@ def test_add_infos_header_commentary():
     # SimulatedData avoids requiring extra keys in infos
     infos = munch.Munch(orig="SimulatedData", instrument="unknown")
 
-    # Add hdr to infos laceholders for everything but hdr
+    # Add hdr to infos placeholders for everything but hdr
     mf = munch.Munch(pixelSize=1.0)
     infos = _add_infos_header(infos, hdr, mf, 1.0, "afilename", "amaskname", 1)
 

--- a/amical/tests/test_io.py
+++ b/amical/tests/test_io.py
@@ -48,7 +48,7 @@ def test_add_infos_header_commentary():
 
     # Create a fits header with commentary card
     hdr = fits.Header()
-    hdr['HISTORY'] = "History is a commentary card"
+    hdr["HISTORY"] = "History is a commentary card"
 
     # SimulatedData avoids requiring extra keys in infos
     infos = munch.Munch(orig="SimulatedData", instrument="unknown")
@@ -59,7 +59,6 @@ def test_add_infos_header_commentary():
 
     # Convert everything to munch object
     dict2class(infos)
-
 
 
 @pytest.mark.slow

--- a/amical/tests/test_io.py
+++ b/amical/tests/test_io.py
@@ -1,4 +1,5 @@
 import munch
+from munch import munchify as dict2class
 import numpy as np
 import pytest
 from astropy.io import fits
@@ -6,6 +7,7 @@ from astropy.io import fits
 import amical
 from amical import load, loadc
 from amical.get_infos_obs import get_pixel_size
+from amical.mf_pipeline.bispect import _add_infos_header
 
 
 @pytest.fixture()
@@ -39,6 +41,24 @@ def example_bss(global_datadir):
             peakmethod=peakmethod,
         )
     return bss
+
+
+def test_add_infos_header():
+
+    # Create a fits header with commentary card
+    hdr = fits.Header()
+    hdr['HISTORY'] = "History is a commentary card"
+
+    # Make sure that simulated data and instrument is not sphere to include header
+    infos = munch.Munch(orig="SimulatedData", instrument="unknown")
+
+    # Add hdr to infos laceholders for everything but hdr
+    mf = munch.Munch(pixelSize=1.0)
+    infos = _add_infos_header(infos, hdr, mf, 1.0, "afilename", "amaskname", 1)
+
+    # Convert everything to munch object
+    dict2class(infos)
+
 
 
 @pytest.mark.slow

--- a/amical/tests/test_io.py
+++ b/amical/tests/test_io.py
@@ -1,5 +1,4 @@
 import munch
-from munch import munchify as dict2class
 import numpy as np
 import pytest
 from astropy.io import fits
@@ -7,7 +6,6 @@ from astropy.io import fits
 import amical
 from amical import load, loadc
 from amical.get_infos_obs import get_pixel_size
-from amical.mf_pipeline.bispect import _add_infos_header
 
 
 @pytest.fixture()
@@ -41,24 +39,6 @@ def example_bss(global_datadir):
             peakmethod=peakmethod,
         )
     return bss
-
-
-def test_add_infos_header_commentary():
-    # Make sure that _add_infos_header handles _HeaderCommentaryCards from astropy
-
-    # Create a fits header with commentary card
-    hdr = fits.Header()
-    hdr["HISTORY"] = "History is a commentary card"
-
-    # SimulatedData avoids requiring extra keys in infos
-    infos = munch.Munch(orig="SimulatedData", instrument="unknown")
-
-    # Add hdr to infos laceholders for everything but hdr
-    mf = munch.Munch(pixelSize=1.0)
-    infos = _add_infos_header(infos, hdr, mf, 1.0, "afilename", "amaskname", 1)
-
-    # Convert everything to munch object
-    dict2class(infos)
 
 
 @pytest.mark.slow

--- a/amical/tests/test_io.py
+++ b/amical/tests/test_io.py
@@ -43,13 +43,14 @@ def example_bss(global_datadir):
     return bss
 
 
-def test_add_infos_header():
+def test_add_infos_header_commentary():
+    # Make sure that _add_infos_header handles _HeaderCommentaryCards from astropy
 
     # Create a fits header with commentary card
     hdr = fits.Header()
     hdr['HISTORY'] = "History is a commentary card"
 
-    # Make sure that simulated data and instrument is not sphere to include header
+    # SimulatedData avoids requiring extra keys in infos
     infos = munch.Munch(orig="SimulatedData", instrument="unknown")
 
     # Add hdr to infos laceholders for everything but hdr


### PR DESCRIPTION
This adds a test for the `_add_infos_header` function, making sure its output is compatible with munch by removing astropy `_HeaderCommentaryCards`, as discussed in #31. The SPHERE example still works and now extraction works for mirage simulations (and should work for actual NIRISS data).