### PR TITLE
ENH: add a conditional to adapt behaviour depending on astropy's version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     matplotlib
     munch
     numpy
+    packaging>=21.0
     scipy
     termcolor
     tqdm


### PR DESCRIPTION
likely a better approach than #59
closes #31
follow up to #45

This should not be merged before Astropy 5.0.0 is out and we can properly test against it.
Note that I'm adding `packaging` as a hard dependency to parse versions. This is the officially recommended way to do this after the equivalent functionality in setuptools was deprecated and targeted for removal in Python 3.12 (expected late 2023).
