### PR TITLE
Add __name__ == '__main__' to fix pool issue

### DIFF
--- a/doc/example_analysis.py
+++ b/doc/example_analysis.py
@@ -28,80 +28,89 @@ inputdata = "Saveoifits/example_fakebinary_NIRISS.oifits"
 use_candid = True
 use_pymask = False
 
-# Analysis with CANDID package
-# ----------------------------
-if use_candid:
-    param_candid = {
-        "rmin": 20,  # inner radius of the grid
-        "rmax": 250,  # outer radius of the grid
-        "step": 50,  # grid sampling
-        "ncore": 2,  # core for multiprocessing
-    }
+if __name__ == "__main__":
+    # Analysis with CANDID package
+    # ----------------------------
+    if use_candid:
+        param_candid = {
+            "rmin": 20,  # inner radius of the grid
+            "rmax": 250,  # outer radius of the grid
+            "step": 50,  # grid sampling
+            "ncore": 2,  # core for multiprocessing
+        }
 
-    # If you want to save the figure locally as .pdf, use save=True (new feature
-    # June 2021).
-    fit1 = amical.candid_grid(
-        inputdata, **param_candid, diam=20, doNotFit=[], save=False
-    )
+        # If you want to save the figure locally as .pdf, use save=True (new feature
+        # June 2021).
 
-    # Plot and save the fitted model
-    amical.plot_model(inputdata, fit1["best"], save=False)
+        fit1 = amical.candid_grid(
+            inputdata, **param_candid, diam=20, doNotFit=[], save=False
+        )
 
-    cr_candid = amical.candid_cr_limit(
-        inputdata, **param_candid, fitComp=fit1["comp"], save=False
-    )
+        # Plot and save the fitted model
+        amical.plot_model(inputdata, fit1["best"], save=False)
 
-# Analysis with PYMASK package
-# ----------------------------
-if use_pymask:
-    param_pymask = {
-        "sep_prior": [100, 180],  # Prior on the separation
-        "pa_prior": [20, 80],  # Prior on the position angle
-        "cr_prior": [230, 270],  # Prior on the contrast ratio
-        "ncore": 12,  # core for multiprocessing
-        "extra_error_cp": 0,
-        "err_scale": 1,
-    }
+        cr_candid = amical.candid_cr_limit(
+            inputdata, **param_candid, fitComp=fit1["comp"], save=False
+        )
 
-    # Pymask proposes to add some extra_error_cp on the CP. This allows to take
-    # into account a possibly understimated uncertainties on the data. Indeed,
-    # some bias due to mismatch between the calibrator and the science spectral type,
-    # or some systematic temporal effect could produce additional errors not properly
-    # retrieved by the covariance matrix.
+    # Analysis with PYMASK package
+    # ----------------------------
+    if use_pymask:
+        param_pymask = {
+            "sep_prior": [100, 180],  # Prior on the separation
+            "pa_prior": [20, 80],  # Prior on the position angle
+            "cr_prior": [230, 270],  # Prior on the contrast ratio
+            "ncore": 12,  # core for multiprocessing
+            "extra_error_cp": 0,
+            "err_scale": 1,
+        }
 
-    # In addition, we can also add some scaling parameter (`err_scale`) on the CP
-    # uncertainties to deal with the number of independant closure phases (N(N-1)(N-2)/6)
-    # compare to the dependant one ((N-1)(N-2)/2). If you considere the full CP set (35 for
-    # a 7 holes mask), you possibly over-use your data, so you have to scale
-    # your uncertainties by the factor of additional CP, which is sqrt(N/3).
+        # Pymask proposes to add some extra_error_cp on the CP. This allows to take
+        # into account a possibly understimated uncertainties on the data. Indeed,
+        # some bias due to mismatch between the calibrator and the science spectral type,
+        # or some systematic temporal effect could produce additional errors not properly
+        # retrieved by the covariance matrix.
 
-    # ** Note that if you used only a subset of CP (by selecting one common hole to
-    # save the oifits, see amical.save for details), this additional `err_scale` is unusable.
+        # In addition, we can also add some scaling parameter (`err_scale`) on the CP
+        # uncertainties to deal with the number of independant closure phases (N(N-1)(N-2)/6)
+        # compare to the dependant one ((N-1)(N-2)/2). If you considere the full CP set (35 for
+        # a 7 holes mask), you possibly over-use your data, so you have to scale
+        # your uncertainties by the factor of additional CP, which is sqrt(N/3).
 
-    fit2 = amical.pymask_grid(inputdata, **param_pymask)
+        # ** Note that if you used only a subset of CP (by selecting one common hole to
+        # save the oifits, see amical.save for details), this additional `err_scale` is unusable.
 
-    param_mcmc = {
-        "niters": 800,
-        "walkers": 100,
-        "initial_guess": [146, 47, 244],
-        "burn_in": 100,
-    }
+        fit2 = amical.pymask_grid(inputdata, **param_pymask)
 
-    fit3 = amical.pymask_mcmc(inputdata, **param_pymask, **param_mcmc)
+        param_mcmc = {
+            "niters": 800,
+            "walkers": 100,
+            "initial_guess": [146, 47, 244],
+            "burn_in": 100,
+        }
 
-    cr_pymask = amical.pymask_cr_limit(
-        inputdata, nsim=500, ncore=12, smax=250, nsep=100, cmax=5000, nth=30, ncrat=60
-    )
+        fit3 = amical.pymask_mcmc(inputdata, **param_pymask, **param_mcmc)
 
-if use_candid & use_pymask:
-    plt.figure()
-    plt.plot(cr_candid["r"], cr_candid["cr_limit"], label="CANDID", alpha=0.5, lw=3)
-    plt.plot(cr_pymask["r"], cr_pymask["cr_limit"], label="Pymask", alpha=0.5, lw=3)
-    plt.ylim(plt.ylim()[1], plt.ylim()[0])  # -- reverse plot
-    plt.xlabel("Separation [mas]")
-    plt.ylabel(r"$\Delta \mathrm{Mag}_{3\sigma}$")
-    plt.legend(loc="best")
-    plt.grid()
-    plt.tight_layout()
+        cr_pymask = amical.pymask_cr_limit(
+            inputdata,
+            nsim=500,
+            ncore=12,
+            smax=250,
+            nsep=100,
+            cmax=5000,
+            nth=30,
+            ncrat=60,
+        )
 
-plt.show(block=True)
+    if use_candid & use_pymask:
+        plt.figure()
+        plt.plot(cr_candid["r"], cr_candid["cr_limit"], label="CANDID", alpha=0.5, lw=3)
+        plt.plot(cr_pymask["r"], cr_pymask["cr_limit"], label="Pymask", alpha=0.5, lw=3)
+        plt.ylim(plt.ylim()[1], plt.ylim()[0])  # -- reverse plot
+        plt.xlabel("Separation [mas]")
+        plt.ylabel(r"$\Delta \mathrm{Mag}_{3\sigma}$")
+        plt.legend(loc="best")
+        plt.grid()
+        plt.tight_layout()
+
+    plt.show(block=True)


### PR DESCRIPTION
Adding `__name__ == '__main__'` condition in the example script (before to call candid_grid(), pymask_mcmc() or any function that use multiprocessing package) fix the issue #54. Some remarks about why we need to use it can be found here (https://stackoverflow.com/questions/20360686/compulsory-usage-of-if-name-main-in-windows-while-using-multiprocessi).