### PR TITLE
Add `origin` keyword to `amical.save()`

### DIFF
--- a/amical/oifits.py
+++ b/amical/oifits.py
@@ -450,9 +450,10 @@ def save(
     include_vis=False,
     true_flag_v2=True,
     true_flag_t3=False,
-    origin=None,
     snr=4,
     verbose=False,
+    *,
+    origin=None,
 ):
     """
     Summary:

--- a/amical/oifits.py
+++ b/amical/oifits.py
@@ -450,6 +450,7 @@ def save(
     include_vis=False,
     true_flag_v2=True,
     true_flag_t3=False,
+    origin=None,
     snr=4,
     verbose=False,
 ):
@@ -466,12 +467,14 @@ def save(
     `input_calibrated` {class}:
         Class or list of class containing all calibrated interferometric variable extracted
         using calibrate (amical.calibration) function,\n
+    `oifits_file` {str}:
+        Name of the oifits file,\n
+    `datadir` {str}:
+        Folder name save the oifits files,\n
     `ind_hole` {int}:
         By default, ind_hole is None, all the CP are considered ncp = N(N-1)(N-2)/6. If
         ind_hole is set, save only the independant CP including the given hole
         ncp = (N-1)(N-2)/2.\n
-    `oifits_file` {str}:
-        Name of the oifits file,\n
     `include_vis` {bool}:
         If True, include OI_VIS table in the oifits,\n
     `fake_obj` {bool}:
@@ -481,10 +484,11 @@ def save(
         Position angle of the observation (i.e.: north direction) [deg],\n
     `true_flag_v2`, `true_flag_t3` {bool}:
         if True, the true flag are used using snr,\n
+    `origin` {str}:
+        String to use as ORIGIN key in oifits. 'Sydney University' is used if origin is
+        `None` (default=None).\n
     `snr` {float}:
         Limit snr used to compute flags (default=4),\n
-    `datadir` {str}:
-        Folder name save the oifits files,\n
     `verbose` {bool}:
         If True, print useful informations.
 
@@ -505,8 +509,12 @@ def save(
         print("Error: oifits filename is not given, please specify oifits_file.")
         return None
 
-    if type(input_calibrated) is not list:
+    if not isinstance(input_calibrated, list):
         input_calibrated = [input_calibrated]
+
+    if origin is not None:
+        if not isinstance(origin, str):
+            raise TypeError("origin should be a str or None")
 
     l_dic = []
     for ical in input_calibrated:
@@ -540,7 +548,10 @@ def save(
     hdu.header["DATE"] = datetime.datetime.now().strftime(
         format="%F"
     )  # , 'Creation date'
-    hdu.header["ORIGIN"] = "Sydney University"
+    if origin is not None:
+        hdu.header["ORIGIN"] = origin
+    else:
+        hdu.header["ORIGIN"] = hdr.get("ORIGIN", "Sydney University")
     hdu.header["CONTENT"] = "OIFITS2"
     hdu.header["DATE-OBS"] = hdr.get("date-obs", "")
     hdu.header["TELESCOP"] = hdr.get("TELESCOP", "")

--- a/amical/oifits.py
+++ b/amical/oifits.py
@@ -548,10 +548,7 @@ def save(
     hdu.header["DATE"] = datetime.datetime.now().strftime(
         format="%F"
     )  # , 'Creation date'
-    if origin is not None:
-        hdu.header["ORIGIN"] = origin
-    else:
-        hdu.header["ORIGIN"] = hdr.get("ORIGIN", "Sydney University")
+    hdu.header["ORIGIN"] = origin or hdr.get("ORIGIN", "Sydney University")
     hdu.header["CONTENT"] = "OIFITS2"
     hdu.header["DATE-OBS"] = hdr.get("date-obs", "")
     hdu.header["TELESCOP"] = hdr.get("TELESCOP", "")

--- a/amical/oifits.py
+++ b/amical/oifits.py
@@ -513,9 +513,8 @@ def save(
     if not isinstance(input_calibrated, list):
         input_calibrated = [input_calibrated]
 
-    if origin is not None:
-        if not isinstance(origin, str):
-            raise TypeError("origin should be a str or None")
+    if not isinstance(origin, (str, type(None))):
+        raise TypeError("origin should be a str or None")
 
     l_dic = []
     for ical in input_calibrated:

--- a/amical/oifits.py
+++ b/amical/oifits.py
@@ -510,7 +510,7 @@ def save(
         print("Error: oifits filename is not given, please specify oifits_file.")
         return None
 
-    if not isinstance(input_calibrated, list):
+    if type(input_calibrated) is not list:
         input_calibrated = [input_calibrated]
 
     if not isinstance(origin, (str, type(None))):

--- a/amical/oifits.py
+++ b/amical/oifits.py
@@ -472,26 +472,26 @@ def save(
         Name of the oifits file,\n
     `datadir` {str}:
         Folder name save the oifits files,\n
+    `pa` {float}:
+        Position angle of the observation (i.e.: north direction) [deg],\n
     `ind_hole` {int}:
         By default, ind_hole is None, all the CP are considered ncp = N(N-1)(N-2)/6. If
         ind_hole is set, save only the independant CP including the given hole
         ncp = (N-1)(N-2)/2.\n
-    `include_vis` {bool}:
-        If True, include OI_VIS table in the oifits,\n
     `fake_obj` {bool}:
         If True, observable are extracted from simulated data and so doesn't
         contain real target informations (simbad search is ignored),\n
-    `pa` {float}:
-        Position angle of the observation (i.e.: north direction) [deg],\n
+    `include_vis` {bool}:
+        If True, include OI_VIS table in the oifits,\n
     `true_flag_v2`, `true_flag_t3` {bool}:
         if True, the true flag are used using snr,\n
-    `origin` {str}:
-        String to use as ORIGIN key in oifits. 'Sydney University' is used if origin is
-        `None` (default=None).\n
     `snr` {float}:
         Limit snr used to compute flags (default=4),\n
     `verbose` {bool}:
         If True, print useful informations.
+    `origin` {str}:
+        String to use as ORIGIN key in oifits. 'Sydney University' is used if origin is
+        `None` (default=None).\n
 
     Returns:
     --------

--- a/amical/tests/test_io.py
+++ b/amical/tests/test_io.py
@@ -105,7 +105,7 @@ def test_origin_type(cal, tmpdir):
 def test_save_origin(cal, tmpdir):
 
     og = "allo"
-    _, savefile = amical.save(
+    _dic, savefile = amical.save(
         cal,
         oifits_file="test_origin.oifits",
         datadir=tmpdir,

--- a/amical/tests/test_io.py
+++ b/amical/tests/test_io.py
@@ -86,7 +86,6 @@ def test_save(cal, tmpdir):
     assert isinstance(cp, np.ndarray)
     assert len(v2) == 21
     assert len(cp) == 35
-    assert len(cp) == 35
     assert hdr["ORIGIN"] == "Sydney University"
 
 

--- a/amical/tests/test_io.py
+++ b/amical/tests/test_io.py
@@ -1,11 +1,13 @@
-import amical
 import munch
 import numpy as np
 import pytest
-from amical import load, loadc
+from astropy.io import fits
+
+import amical
+from amical import load
+from amical import loadc
 from amical.externals import pymask
 from amical.get_infos_obs import get_pixel_size
-from astropy.io import fits
 
 
 @pytest.fixture()


### PR DESCRIPTION
After talking to @DrSoulain, I added the option to override the "Sydney University" value of "ORIGIN" in the output oifits file. The new behaviour is:
- If `origin` is specified, use this (error is raised if it is not a string).
- If `origin` is None, try to use the value from the input files, fallback to "Sydney University".

I added the corresponding tests in `test_io.py`. I also refactored it slightly to make `cal` a fixture now that it's used in many places.