### PR TITLE
Enable saving raw observables to oifits files with `amical.save()`

### DIFF
--- a/amical/oifits.py
+++ b/amical/oifits.py
@@ -562,14 +562,15 @@ def save(
 
     l_dic = []
     for iobs in observables:
-        # If keys corresponding raw observables, make format compatible with calibrated
+        # If keys correspond to raw observables, make format compatible with calibrated
         if "cp" in iobs and "raw_t" not in iobs:
             if not raw and verbose:
                 msg = (
                     "The input seems to contain uncalibrated observables."
-                    "Saving raw observables as oifits is provided only for convenience."
-                    "To re-use the observables in amical.calibrate(), they should be"
-                    "saved to a pickle file. Use raw=True to turn this warning off."
+                    " Saving raw observables as oifits is provided only for"
+                    " convenience. To re-use the observables in amical.calibrate(),"
+                    " they should be saved to a pickle file. Use raw=True to turn this"
+                    " warning off."
                 )
                 cprint(f"Warning: {msg}", "green")
             iobs = wrap_raw(iobs)

--- a/amical/oifits.py
+++ b/amical/oifits.py
@@ -568,7 +568,8 @@ def save(
             if not raw:
                 msg = (
                     "The input seems to contain uncalibrated observables. Use raw=True"
-                    "to turn this warning off.")
+                    "to turn this warning off."
+                )
                 warnings.warn(msg, RuntimeWarning)
             iobs = wrap_raw(iobs)
         idic = cal2dict(

--- a/amical/oifits.py
+++ b/amical/oifits.py
@@ -135,7 +135,7 @@ def wrap_raw(bs):
     u2 = bs.u[bs.mask.bs2bl_ix[1, :]]
     v2 = bs.v[bs.mask.bs2bl_ix[1, :]]
 
-    fake_cale_cal = {
+    fake_cal = {
         "vis2": bs.vis2,
         "e_vis2": bs.e_vis2,
         "cp": bs.cp,
@@ -151,7 +151,7 @@ def wrap_raw(bs):
         "raw_c": bs,
     }
 
-    return dict2class(fake_cale_cal)
+    return dict2class(fake_cal)
 
 
 def cal2dict(

--- a/amical/oifits.py
+++ b/amical/oifits.py
@@ -11,7 +11,6 @@ OIFITS related function.
 """
 import datetime
 import os
-import warnings
 
 import numpy as np
 from astropy import units as u
@@ -565,12 +564,12 @@ def save(
     for iobs in observables:
         # If keys corresponding raw observables, make format compatible with calibrated
         if "cp" in iobs and "raw_t" not in iobs:
-            if not raw:
+            if not raw and verbose:
                 msg = (
                     "The input seems to contain uncalibrated observables. Use raw=True"
                     "to turn this warning off."
                 )
-                warnings.warn(msg, RuntimeWarning)
+                cprint(f"Warning: {msg}", "green")
             iobs = wrap_raw(iobs)
         idic = cal2dict(
             iobs,

--- a/amical/oifits.py
+++ b/amical/oifits.py
@@ -566,8 +566,10 @@ def save(
         if "cp" in iobs and "raw_t" not in iobs:
             if not raw and verbose:
                 msg = (
-                    "The input seems to contain uncalibrated observables. Use raw=True"
-                    "to turn this warning off."
+                    "The input seems to contain uncalibrated observables."
+                    "Saving raw observables as oifits is provided only for convenience."
+                    "To re-use the observables in amical.calibrate(), they should be"
+                    "saved to a pickle file. Use raw=True to turn this warning off."
                 )
                 cprint(f"Warning: {msg}", "green")
             iobs = wrap_raw(iobs)

--- a/amical/tests/test_io.py
+++ b/amical/tests/test_io.py
@@ -69,7 +69,7 @@ def test_show(cal):
     amical.show(cal)
 
 
-def test_save(cal, tmpdir):
+def test_save_cal(cal, tmpdir):
 
     dic, savefile = amical.save(
         cal, oifits_file="test_cal.oifits", datadir=tmpdir, fake_obj=True
@@ -87,6 +87,27 @@ def test_save(cal, tmpdir):
     assert len(v2) == 21
     assert len(cp) == 35
     assert hdr["ORIGIN"] == "Sydney University"
+
+
+def test_save_raw(bss, tmpdir):
+    bs = bss["fft"]
+
+    dic, savefile = amical.save(
+        bs, oifits_file="test_raw.oifits", datadir=tmpdir, fake_obj=True
+    )
+
+    assert isinstance(dic, dict)
+    assert isinstance(savefile, str)
+
+    hdr = fits.getheader(savefile)
+    v2 = dic["OI_VIS2"]["VIS2DATA"]
+    cp = dic["OI_T3"]["T3PHI"]
+
+    assert isinstance(v2, np.ndarray)
+    assert isinstance(cp, np.ndarray)
+    assert len(v2) == 21
+    assert len(cp) == 35
+    assert hdr["OBJECT"] == hdr["CALIB"]
 
 
 def test_origin_type(cal, tmpdir):


### PR DESCRIPTION
This adds the possibility to give uncalibrated observables (i.e. the output from `amical.extract_bs()`) to `amical.save()` and save them to oifits. While doing this is probably not a good idea for scientific analysis, it can be useful to save the raw observables in a standard format and inspect them later or compare them with similar output other tools.

To avoid rewriting a whole `cal2dict` but for raw observables, I simply defined a `wrap_bs()` function that makes the format of the raw observables compatible with the calibrated ones. Because it's bit of a niche use case, I added a warning that can be silenced with a new keyword argument (`raw`). I have a few questions:

- Is it OK to use `warnings.warn()` for the warning or should I use `cprint()` as in other areas of AMICAL ?
- Is the attribute check done to infer that the observables are not calibrated OK or should I use a try/except here ?
- Is it OK to put this in `save()` or should it be in `cal2dict`. I put it in `save()` directly for now because it avoids carrying the `raw` kwarg to another function and and makes cal2dict work only with a single format of data.

Also, this includes the changes from #66 because they affect the same functions. I can clean this one up when #66 is merged.