### PR TITLE
ENH: do not turn pyplot's interactive mode on at import time

### DIFF
--- a/amical/externals/candid/candid.py
+++ b/amical/externals/candid/candid.py
@@ -11,7 +11,6 @@ import scipy.stats
 from matplotlib import pyplot as plt
 from scipy.special import factorial
 
-plt.ion()  # interactive mode
 _fitsLoaded = False
 try:
     from astropy.io import fits


### PR DESCRIPTION
This single line is making pdb usable, so `pytest --pdb` is currently useless in AMICAL. Furthermore, changing matplotlib's global state at import time seems like an unreasonable side effect.

Related to #53