### PR TITLE
ENH: Add conditional to adapt behaviour depending on astropy version and warn user

### DIFF
--- a/amical/mf_pipeline/bispect.py
+++ b/amical/mf_pipeline/bispect.py
@@ -41,7 +41,7 @@ from amical.tools import compute_pa
 from amical.tools import cov2cor
 
 
-ASTROPY_VERSION = astropy.__version__
+ASTROPY_VERSION = Version(astropy.__version__)
 
 
 def _compute_complex_bs(
@@ -993,7 +993,7 @@ def _add_infos_header(infos, hdr, mf, pa, filename, maskname, npix):
 
     hdr_commentary_keys = fits.Card._commentary_keywords
     if any(hck in hdr for hck in hdr_commentary_keys) and (
-        Version(ASTROPY_VERSION) < Version("5.0rc")
+        ASTROPY_VERSION < Version("5.0rc")
     ):
         warnings.warn(
             "Commentary cards are removed from the header with astropy"

--- a/amical/mf_pipeline/bispect.py
+++ b/amical/mf_pipeline/bispect.py
@@ -15,11 +15,13 @@ and calc_bispect.pro).
 import sys
 import time
 
+import astropy
 import numpy as np
 from astropy.io import fits
 from matplotlib import pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from munch import munchify as dict2class
+from packaging.version import Version
 from scipy.optimize import minimize
 from termcolor import cprint
 from tqdm import tqdm
@@ -985,19 +987,21 @@ def _add_infos_header(infos, hdr, mf, pa, filename, maskname, npix):
     infos["maskname"] = maskname
     infos["isz"] = npix
 
-    # HACK: astropy _HeaderCommentaryCards are registered as mappings,
-    # so munch tries to access their keys, leading to attribute error
-    # to prevent this, we remove commentary cards as a temporary fix.
-    # (As of June 23 2021, with astropy version 4.2.1)
-    # See:
-    # https://github.com/SydneyAstrophotonicInstrumentationLab/AMICAL/issues/31
-    # https://github.com/astropy/astropy/issues/11866
-    hdr_commentary_keys = fits.Card._commentary_keywords
-    hdr = hdr.copy()
-    for key in hdr_commentary_keys:
-        hdr.remove(key, ignore_missing=True, remove_all=True)
+    if Version(astropy.__version__) < Version("5.0.0"):
+        # HACK: astropy _HeaderCommentaryCards are registered as mappings,
+        # so munch tries to access their keys, leading to attribute error
+        # to prevent this, we remove commentary cards as a temporary fix.
+        # (As of September 2 2021, with astropy version 4.3.1)
+        # See:
+        # https://github.com/SydneyAstrophotonicInstrumentationLab/AMICAL/issues/31
+        # https://github.com/astropy/astropy/issues/11866
+        # Resolved upstream with
+        # https://github.com/astropy/astropy/pull/11923
+        hdr_commentary_keys = fits.Card._commentary_keywords
+        hdr = hdr.copy()
+        for key in hdr_commentary_keys:
+            hdr.remove(key, ignore_missing=True, remove_all=True)
 
-    # Now that header is compatible with munch, we add it to infos
     infos["hdr"] = hdr
 
     # Save keys of the original header (as needed):

--- a/amical/mf_pipeline/bispect.py
+++ b/amical/mf_pipeline/bispect.py
@@ -988,7 +988,7 @@ def _add_infos_header(infos, hdr, mf, pa, filename, maskname, npix, verbose=True
     infos["isz"] = npix
 
     astropy_version = astropy.__version__
-    working_version = "5.0.0"
+    working_version = "5.0rc1"
     if Version(astropy_version) < Version(working_version):
         if verbose:
             cprint(

--- a/amical/mf_pipeline/bispect.py
+++ b/amical/mf_pipeline/bispect.py
@@ -993,8 +993,8 @@ def _add_infos_header(infos, hdr, mf, pa, filename, maskname, npix, verbose=True
         if verbose:
             cprint(
                 "Commentary cards are removed from the header with astropy"
-                f"version < {working_version}. Your astropy version is"
-                f"{astropy_version}",
+                f" version < {working_version}. Your astropy version is"
+                f" {astropy_version}",
                 "green",
             )
         # HACK: astropy _HeaderCommentaryCards are registered as mappings,

--- a/amical/mf_pipeline/bispect.py
+++ b/amical/mf_pipeline/bispect.py
@@ -983,7 +983,7 @@ def _compute_phs_error(complex_bs, fitmat, index_mask, npix, imsize=3):
     return phs_v2corr
 
 
-def _add_infos_header(infos, hdr, mf, pa, filename, maskname, npix, verbose=True):
+def _add_infos_header(infos, hdr, mf, pa, filename, maskname, npix):
     """Save important informations and some parts of the original header."""
     infos["pixscale"] = mf.pixelSize
     infos["pa"] = pa
@@ -995,13 +995,12 @@ def _add_infos_header(infos, hdr, mf, pa, filename, maskname, npix, verbose=True
     if any(hck in hdr for hck in hdr_commentary_keys) and (
         Version(ASTROPY_VERSION) < Version("5.0rc")
     ):
-        if verbose:
-            warnings.warn(
-                "Commentary cards are removed from the header with astropy"
-                f" version < 5.0. Your astropy version is"
-                f" {ASTROPY_VERSION}",
-                RuntimeWarning,
-            )
+        warnings.warn(
+            "Commentary cards are removed from the header with astropy"
+            f" version < 5.0. Your astropy version is"
+            f" {ASTROPY_VERSION}",
+            RuntimeWarning,
+        )
         # HACK: astropy _HeaderCommentaryCards are registered as mappings,
         # so munch tries to access their keys, leading to attribute error
         # to prevent this, we remove commentary cards as a temporary fix.

--- a/amical/mf_pipeline/bispect.py
+++ b/amical/mf_pipeline/bispect.py
@@ -991,6 +991,8 @@ def _add_infos_header(infos, hdr, mf, pa, filename, maskname, npix):
     infos["maskname"] = maskname
     infos["isz"] = npix
 
+    # Raise a warning that old astropy version drop commentary cards, but only if
+    # there are any in the original header
     hdr_commentary_keys = fits.Card._commentary_keywords
     if any(hck in hdr for hck in hdr_commentary_keys) and (
         ASTROPY_VERSION < Version("5.0rc")

--- a/amical/mf_pipeline/bispect.py
+++ b/amical/mf_pipeline/bispect.py
@@ -979,7 +979,7 @@ def _compute_phs_error(complex_bs, fitmat, index_mask, npix, imsize=3):
     return phs_v2corr
 
 
-def _add_infos_header(infos, hdr, mf, pa, filename, maskname, npix):
+def _add_infos_header(infos, hdr, mf, pa, filename, maskname, npix, verbose=True):
     """Save important informations and some parts of the original header."""
     infos["pixscale"] = mf.pixelSize
     infos["pa"] = pa
@@ -987,7 +987,16 @@ def _add_infos_header(infos, hdr, mf, pa, filename, maskname, npix):
     infos["maskname"] = maskname
     infos["isz"] = npix
 
-    if Version(astropy.__version__) < Version("5.0.0"):
+    astropy_version = astropy.__version__
+    working_version = "5.0.0"
+    if Version(astropy_version) < Version(working_version):
+        if verbose:
+            cprint(
+                "Commentary cards are removed from the header with astropy"
+                f"version < {working_version}. Your astropy version is"
+                f"{astropy_version}",
+                "green",
+            )
         # HACK: astropy _HeaderCommentaryCards are registered as mappings,
         # so munch tries to access their keys, leading to attribute error
         # to prevent this, we remove commentary cards as a temporary fix.

--- a/amical/mf_pipeline/bispect.py
+++ b/amical/mf_pipeline/bispect.py
@@ -41,6 +41,9 @@ from amical.tools import compute_pa
 from amical.tools import cov2cor
 
 
+ASTROPY_VERSION = astropy.__version__
+
+
 def _compute_complex_bs(
     ft_arr,
     index_mask,
@@ -988,17 +991,15 @@ def _add_infos_header(infos, hdr, mf, pa, filename, maskname, npix, verbose=True
     infos["maskname"] = maskname
     infos["isz"] = npix
 
-    astropy_version = astropy.__version__
-    working_version = "5.0rc1"
     hdr_commentary_keys = fits.Card._commentary_keywords
     if any(hck in hdr for hck in hdr_commentary_keys) and (
-        Version(astropy_version) < Version(working_version)
+        Version(ASTROPY_VERSION) < Version("5.0rc")
     ):
         if verbose:
             warnings.warn(
                 "Commentary cards are removed from the header with astropy"
-                f" version < {working_version}. Your astropy version is"
-                f" {astropy_version}",
+                f" version < 5.0. Your astropy version is"
+                f" {ASTROPY_VERSION}",
                 RuntimeWarning,
             )
         # HACK: astropy _HeaderCommentaryCards are registered as mappings,

--- a/amical/tests/test_extraction.py
+++ b/amical/tests/test_extraction.py
@@ -83,5 +83,8 @@ def test_no_commentary_warning_astropy_version():
     hdr = fits.Header()
     hdr["HISTORY"] = "History is a commentary card"
 
-    with pytest.warns(RuntimeWarning, match="Commentary cards"):
+    with pytest.warns(
+        RuntimeWarning,
+        match="Commentary cards are removed from the header with astropy"
+    ):
         infos = _add_infos_header(infos, hdr, mf, 1.0, "afilename", "amaskname", 1)

--- a/amical/tests/test_extraction.py
+++ b/amical/tests/test_extraction.py
@@ -24,7 +24,7 @@ def commentary_hdr():
 def astropy_versions():
 
     astropy_version = astropy.__version__
-    working_version = "5.0.0"
+    working_version = "5.0rc1"
 
     return astropy_version, working_version
 

--- a/amical/tests/test_extraction.py
+++ b/amical/tests/test_extraction.py
@@ -12,12 +12,6 @@ ASTROPY_VERSION = Version(astropy.__version__)
 
 
 @pytest.fixture()
-def infos():
-    # SimulatedData avoids requiring extra keys in infos
-    return munch.Munch(orig="SimulatedData", instrument="unknown")
-
-
-@pytest.fixture()
 def commentary_hdr():
     # Create a fits header with commentary card
     hdr = fits.Header()
@@ -26,23 +20,29 @@ def commentary_hdr():
 
 
 @pytest.fixture()
-def commentary_infos(infos, commentary_hdr):
+def commentary_infos(commentary_hdr):
 
     # Add hdr to infos placeholders for everything but hdr
     mf = munch.Munch(pixelSize=1.0)
+
+    # SimulatedData avoids requiring extra keys in infos
+    infos = munch.Munch(orig="SimulatedData", instrument="unknown")
 
     return _add_infos_header(
         infos, commentary_hdr, mf, 1.0, "afilename", "amaskname", 1
     )
 
 
-def test_add_infos_simulated(infos):
+def test_add_infos_simulated():
     # Ensure that keys are passed to infos for simulated data, but only when available
 
     # Create a fits header with two keywords that are usually passed to infos
     hdr = fits.Header()
     hdr["DATE-OBS"] = "2021-06-23"
     hdr["TELESCOP"] = "FAKE-TEL"
+
+    # SimulatedData avoids requiring extra keys in infos
+    infos = munch.Munch(orig="SimulatedData", instrument="unknown")
 
     # Add hdr to infos placeholders for everything but hdr
     mf = munch.Munch(pixelSize=1.0)
@@ -86,10 +86,13 @@ def test_commentary_infos_drops(commentary_infos):
     ASTROPY_VERSION >= Version("5.0rc"),
     reason="There are no warnings raised for Astropy 5.0+",
 )
-def test_commentary_warning_astropy_version(infos, commentary_hdr):
+def test_commentary_warning_astropy_version(commentary_hdr):
 
     # Add hdr to infos placeholders for everything but hdr
     mf = munch.Munch(pixelSize=1.0)
+
+    # SimulatedData avoids requiring extra keys in infos
+    infos = munch.Munch(orig="SimulatedData", instrument="unknown")
 
     with pytest.warns(RuntimeWarning, match="Commentary cards"):
         infos = _add_infos_header(
@@ -105,10 +108,13 @@ def test_commentary_warning_astropy_version(infos, commentary_hdr):
     ASTROPY_VERSION >= Version("5.0rc"),
     reason="AMICAL should not raise a warning for commentary cards with astropy 5.0+",
 )
-def test_no_commentary_warning_astropy_version(infos, commentary_hdr):
+def test_no_commentary_warning_astropy_version(commentary_hdr):
 
     # Add hdr to infos placeholders for everything but hdr
     mf = munch.Munch(pixelSize=1.0)
+
+    # SimulatedData avoids requiring extra keys in infos
+    infos = munch.Munch(orig="SimulatedData", instrument="unknown")
 
     with pytest.warns(RuntimeWarning, match="Commentary cards"):
         infos = _add_infos_header(

--- a/amical/tests/test_extraction.py
+++ b/amical/tests/test_extraction.py
@@ -1,6 +1,6 @@
-import pytest
 import astropy
 import munch
+import pytest
 from astropy.io import fits
 from packaging.version import Version
 
@@ -20,6 +20,7 @@ def commentary_hdr():
     hdr["HISTORY"] = "History is a commentary card"
     return hdr
 
+
 @pytest.fixture()
 def astropy_versions():
 
@@ -29,14 +30,15 @@ def astropy_versions():
     return astropy_version, working_version
 
 
-
 @pytest.fixture
 def commentary_infos(infos, commentary_hdr):
 
     # Add hdr to infos placeholders for everything but hdr
     mf = munch.Munch(pixelSize=1.0)
 
-    return _add_infos_header(infos, commentary_hdr, mf, 1.0, "afilename", "amaskname", 1)
+    return _add_infos_header(
+        infos, commentary_hdr, mf, 1.0, "afilename", "amaskname", 1
+    )
 
 
 def test_add_infos_simulated(infos):
@@ -83,7 +85,9 @@ def test_astropy_version_warning(infos, commentary_hdr, astropy_versions, capfd)
     # Add hdr to infos placeholders for everything but hdr
     mf = munch.Munch(pixelSize=1.0)
 
-    infos = _add_infos_header(infos, commentary_hdr, mf, 1.0, "afilename", "amaskname", 1)
+    infos = _add_infos_header(
+        infos, commentary_hdr, mf, 1.0, "afilename", "amaskname", 1
+    )
     captured = capfd.readouterr()
 
     if Version(astropy_version) < Version(working_version):

--- a/amical/tests/test_extraction.py
+++ b/amical/tests/test_extraction.py
@@ -1,19 +1,51 @@
+import pytest
+import astropy
 import munch
 from astropy.io import fits
+from packaging.version import Version
 
 from amical.mf_pipeline.bispect import _add_infos_header
 
 
-def test_add_infos_simulated():
+@pytest.fixture()
+def infos():
+    # SimulatedData avoids requiring extra keys in infos
+    return munch.Munch(orig="SimulatedData", instrument="unknown")
+
+
+@pytest.fixture()
+def commentary_hdr():
+    # Create a fits header with commentary card
+    hdr = fits.Header()
+    hdr["HISTORY"] = "History is a commentary card"
+    return hdr
+
+@pytest.fixture()
+def astropy_versions():
+
+    astropy_version = astropy.__version__
+    working_version = "5.0.0"
+
+    return astropy_version, working_version
+
+
+
+@pytest.fixture
+def commentary_infos(infos, commentary_hdr):
+
+    # Add hdr to infos placeholders for everything but hdr
+    mf = munch.Munch(pixelSize=1.0)
+
+    return _add_infos_header(infos, commentary_hdr, mf, 1.0, "afilename", "amaskname", 1)
+
+
+def test_add_infos_simulated(infos):
     # Ensure that keys are passed to infos for simulated data, but only when available
 
     # Create a fits header with two keywords that are usually passed to infos
     hdr = fits.Header()
     hdr["DATE-OBS"] = "2021-06-23"
     hdr["TELESCOP"] = "FAKE-TEL"
-
-    # This test is for simulated data only
-    infos = munch.Munch(orig="SimulatedData", instrument="unknown")
 
     # Add hdr to infos placeholders for everything but hdr
     mf = munch.Munch(pixelSize=1.0)
@@ -22,21 +54,45 @@ def test_add_infos_simulated():
     assert infos["date-obs"] == hdr["DATE-OBS"]
     assert infos["telescop"] == hdr["TELESCOP"]
     assert "observer" not in infos  # Keys that are not in hdr should not be in infos
+    assert "observer" not in infos.hdr  # Keys that are not in hdr should still not be
 
 
-def test_add_infos_header_commentary():
+def test_add_infos_header_commentary(commentary_infos):
     # Make sure that _add_infos_header handles _HeaderCommentaryCards from astropy
 
-    # Create a fits header with commentary card
-    hdr = fits.Header()
-    hdr["HISTORY"] = "History is a commentary card"
+    # Convert everything to munch object
+    munch.munchify(commentary_infos)
 
-    # SimulatedData avoids requiring extra keys in infos
-    infos = munch.Munch(orig="SimulatedData", instrument="unknown")
+
+def test_commentary_infos_keep(commentary_infos, astropy_versions):
+    # Check that commentary cards are removed or kept depending on astropy version
+
+    astropy_version, working_version = astropy_versions
+
+    if Version(astropy_version) < Version(working_version):
+        assert "HISTORY" not in commentary_infos.hdr
+    else:
+        assert "HISTORY" in commentary_infos.hdr
+
+
+def test_astropy_version_warning(infos, commentary_hdr, astropy_versions, capfd):
+    # Test that AMICAL warns about astropy < 5.0 removing commentary cards
+
+    astropy_version, working_version = astropy_versions
 
     # Add hdr to infos placeholders for everything but hdr
     mf = munch.Munch(pixelSize=1.0)
-    infos = _add_infos_header(infos, hdr, mf, 1.0, "afilename", "amaskname", 1)
 
-    # Convert everything to munch object
-    munch.munchify(infos)
+    infos = _add_infos_header(infos, commentary_hdr, mf, 1.0, "afilename", "amaskname", 1)
+    captured = capfd.readouterr()
+
+    if Version(astropy_version) < Version(working_version):
+        # NOTE: Adding colors codes because output with cprint has them
+        msg = (
+            "\x1b[32mCommentary cards are removed from the header with astropy"
+            f" version < {working_version}. Your astropy version is"
+            f" {astropy_version}\x1b[0m\n"
+        )
+        assert captured.out == msg
+    else:
+        assert not captured.out

--- a/amical/tests/test_extraction.py
+++ b/amical/tests/test_extraction.py
@@ -12,15 +12,7 @@ ASTROPY_VERSION = Version(astropy.__version__)
 
 
 @pytest.fixture()
-def commentary_hdr():
-    # Create a fits header with commentary card
-    hdr = fits.Header()
-    hdr["HISTORY"] = "History is a commentary card"
-    return hdr
-
-
-@pytest.fixture()
-def commentary_infos(commentary_hdr):
+def commentary_infos():
 
     # Add hdr to infos placeholders for everything but hdr
     mf = munch.Munch(pixelSize=1.0)
@@ -28,9 +20,11 @@ def commentary_infos(commentary_hdr):
     # SimulatedData avoids requiring extra keys in infos
     infos = munch.Munch(orig="SimulatedData", instrument="unknown")
 
-    return _add_infos_header(
-        infos, commentary_hdr, mf, 1.0, "afilename", "amaskname", 1
-    )
+    # Create a fits header with commentary card
+    hdr = fits.Header()
+    hdr["HISTORY"] = "History is a commentary card"
+
+    return _add_infos_header(infos, hdr, mf, 1.0, "afilename", "amaskname", 1)
 
 
 def test_add_infos_simulated():
@@ -86,7 +80,7 @@ def test_commentary_infos_drops(commentary_infos):
     ASTROPY_VERSION >= Version("5.0rc"),
     reason="There are no warnings raised for Astropy 5.0+",
 )
-def test_commentary_warning_astropy_version(commentary_hdr):
+def test_commentary_warning_astropy_version():
 
     # Add hdr to infos placeholders for everything but hdr
     mf = munch.Munch(pixelSize=1.0)
@@ -94,10 +88,12 @@ def test_commentary_warning_astropy_version(commentary_hdr):
     # SimulatedData avoids requiring extra keys in infos
     infos = munch.Munch(orig="SimulatedData", instrument="unknown")
 
+    # Create a fits header with commentary card
+    hdr = fits.Header()
+    hdr["HISTORY"] = "History is a commentary card"
+
     with pytest.warns(RuntimeWarning, match="Commentary cards"):
-        infos = _add_infos_header(
-            infos, commentary_hdr, mf, 1.0, "afilename", "amaskname", 1
-        )
+        infos = _add_infos_header(infos, hdr, mf, 1.0, "afilename", "amaskname", 1)
 
 
 @pytest.mark.skipif(
@@ -108,7 +104,7 @@ def test_commentary_warning_astropy_version(commentary_hdr):
     ASTROPY_VERSION >= Version("5.0rc"),
     reason="AMICAL should not raise a warning for commentary cards with astropy 5.0+",
 )
-def test_no_commentary_warning_astropy_version(commentary_hdr):
+def test_no_commentary_warning_astropy_version():
 
     # Add hdr to infos placeholders for everything but hdr
     mf = munch.Munch(pixelSize=1.0)
@@ -116,7 +112,9 @@ def test_no_commentary_warning_astropy_version(commentary_hdr):
     # SimulatedData avoids requiring extra keys in infos
     infos = munch.Munch(orig="SimulatedData", instrument="unknown")
 
+    # Create a fits header with commentary card
+    hdr = fits.Header()
+    hdr["HISTORY"] = "History is a commentary card"
+
     with pytest.warns(RuntimeWarning, match="Commentary cards"):
-        infos = _add_infos_header(
-            infos, commentary_hdr, mf, 1.0, "afilename", "amaskname", 1
-        )
+        infos = _add_infos_header(infos, hdr, mf, 1.0, "afilename", "amaskname", 1)

--- a/amical/tests/test_extraction.py
+++ b/amical/tests/test_extraction.py
@@ -66,13 +66,14 @@ def test_add_infos_header_commentary(commentary_infos):
     munch.munchify(commentary_infos)
 
 
-def test_commentary_infos_keep(commentary_infos, astropy_versions):
-    # Check that commentary cards are removed or kept depending on astropy version
+ASTROPY_VERSION = Version(astropy.__version__)
+@pytest.mark.skipif(ASTROPY_VERSION < Version("5.0rc"), reason="...")
+def test_commentary_infos_keep(commentary_infos):
+     assert "HISTORY" in commentary_infos.hdr
 
-    astropy_version, working_version = astropy_versions
-
-    if Version(astropy_version) < Version(working_version):
-        assert "HISTORY" not in commentary_infos.hdr
+@pytest.mark.skipif(ASTROPY_VERSION >= Version("5.0rc"), reason="...")
+def test_commentary_infos_drops(commentary_infos):
+     assert "HISTORY" not in commentary_infos.hdr
     else:
         assert "HISTORY" in commentary_infos.hdr
 

--- a/amical/tests/test_extraction.py
+++ b/amical/tests/test_extraction.py
@@ -42,10 +42,13 @@ def test_add_infos_simulated():
     mf = munch.Munch(pixelSize=1.0)
     infos = _add_infos_header(infos, hdr, mf, 1.0, "afilename", "amaskname", 1)
 
+    # Check that we kept required keys
     assert infos["date-obs"] == hdr["DATE-OBS"]
     assert infos["telescop"] == hdr["TELESCOP"]
-    assert "observer" not in infos  # Keys that are not in hdr should not be in infos
-    assert "observer" not in infos.hdr  # Keys that are not in hdr should still not be
+
+    # Keys that are not in hdr should not be in infos or hdr
+    assert "observer" not in infos
+    assert "observer" not in infos.hdr
 
 
 @pytest.mark.filterwarnings("ignore: Commentary cards")
@@ -56,7 +59,7 @@ def test_add_infos_header_commentary(commentary_infos):
     munch.munchify(commentary_infos)
 
 
-@pytest.mark.skipif(
+@pytest.mark.xfail(
     ASTROPY_VERSION < Version("5.0rc"),
     reason="Munch cannot handle commentary cards for Astropy < 5.0",
 )
@@ -64,45 +67,9 @@ def test_commentary_infos_keep(commentary_infos):
     assert "HISTORY" in commentary_infos.hdr
 
 
-@pytest.mark.skipif(
-    ASTROPY_VERSION >= Version("5.0rc"),
-    reason="Munch can handle commentary cards for Astropy 5.0+",
-)
 @pytest.mark.xfail(
-    ASTROPY_VERSION < Version("5.0rc"),
-    reason="AMICAL removes commentary cards from header with Astropy < 5.0",
-)
-def test_commentary_infos_drops(commentary_infos):
-    assert "HISTORY" in commentary_infos.hdr
-
-
-@pytest.mark.skipif(
-    ASTROPY_VERSION >= Version("5.0rc"),
-    reason="There are no warnings raised for Astropy 5.0+",
-)
-def test_commentary_warning_astropy_version():
-
-    # Add hdr to infos placeholders for everything but hdr
-    mf = munch.Munch(pixelSize=1.0)
-
-    # SimulatedData avoids requiring extra keys in infos
-    infos = munch.Munch(orig="SimulatedData", instrument="unknown")
-
-    # Create a fits header with commentary card
-    hdr = fits.Header()
-    hdr["HISTORY"] = "History is a commentary card"
-
-    with pytest.warns(RuntimeWarning, match="Commentary cards"):
-        infos = _add_infos_header(infos, hdr, mf, 1.0, "afilename", "amaskname", 1)
-
-
-@pytest.mark.skipif(
-    ASTROPY_VERSION < Version("5.0rc"),
-    reason="Astropy < 5.0 should raise a warning for commentary cards",
-)
-@pytest.mark.xfail(
-    ASTROPY_VERSION >= Version("5.0rc"),
-    reason="AMICAL should not raise a warning for commentary cards with astropy 5.0+",
+    ASTROPY_VERSION > Version("5.0rc"),
+    reason="Astropy > 5.0 should not raise a warning for commentary cards",
 )
 def test_no_commentary_warning_astropy_version():
 

--- a/amical/tests/test_extraction.py
+++ b/amical/tests/test_extraction.py
@@ -9,7 +9,6 @@ from amical.mf_pipeline.bispect import _add_infos_header
 
 # Astropy versions for
 ASTROPY_VERSION = Version(astropy.__version__)
-ASTROPY_WORKING = Version("5.0rc")
 
 
 @pytest.fixture()
@@ -64,7 +63,7 @@ def test_add_infos_header_commentary(commentary_infos):
 
 
 @pytest.mark.skipif(
-    ASTROPY_VERSION < ASTROPY_WORKING,
+    ASTROPY_VERSION < Version("5.0rc"),
     reason="Munch cannot handle commentary cards for Astropy < 5.0",
 )
 def test_commentary_infos_keep(commentary_infos):
@@ -72,11 +71,11 @@ def test_commentary_infos_keep(commentary_infos):
 
 
 @pytest.mark.skipif(
-    ASTROPY_VERSION >= ASTROPY_WORKING,
+    ASTROPY_VERSION >= Version("5.0rc"),
     reason="Munch can handle commentary cards for Astropy 5.0+",
 )
 @pytest.mark.xfail(
-    ASTROPY_VERSION < ASTROPY_WORKING,
+    ASTROPY_VERSION < Version("5.0rc"),
     reason="AMICAL removes commentary cards from header with Astropy < 5.0",
 )
 def test_commentary_infos_drops(commentary_infos):
@@ -84,7 +83,7 @@ def test_commentary_infos_drops(commentary_infos):
 
 
 @pytest.mark.skipif(
-    ASTROPY_VERSION >= ASTROPY_WORKING,
+    ASTROPY_VERSION >= Version("5.0rc"),
     reason="There are no warnings raised for Astropy 5.0+",
 )
 def test_commentary_warning_astropy_version(infos, commentary_hdr):
@@ -99,11 +98,11 @@ def test_commentary_warning_astropy_version(infos, commentary_hdr):
 
 
 @pytest.mark.skipif(
-    ASTROPY_VERSION < ASTROPY_WORKING,
+    ASTROPY_VERSION < Version("5.0rc"),
     reason="Astropy < 5.0 should raise a warning for commentary cards",
 )
 @pytest.mark.xfail(
-    ASTROPY_VERSION >= ASTROPY_WORKING,
+    ASTROPY_VERSION >= Version("5.0rc"),
     reason="AMICAL should not raise a warning for commentary cards with astropy 5.0+",
 )
 def test_no_commentary_warning_astropy_version(infos, commentary_hdr):

--- a/amical/tests/test_extraction.py
+++ b/amical/tests/test_extraction.py
@@ -55,6 +55,7 @@ def test_add_infos_simulated(infos):
     assert "observer" not in infos.hdr  # Keys that are not in hdr should still not be
 
 
+@pytest.mark.filterwarnings("ignore: Commentary cards")
 def test_add_infos_header_commentary(commentary_infos):
     # Make sure that _add_infos_header handles _HeaderCommentaryCards from astropy
 
@@ -82,24 +83,13 @@ def test_commentary_infos_drops(commentary_infos):
     assert "HISTORY" in commentary_infos.hdr
 
 
-def test_astropy_version_warning(infos, commentary_hdr, capfd):
+def test_astropy_version_warning(infos, commentary_hdr):
     # Test that AMICAL warns about astropy < 5.0 removing commentary cards
 
     # Add hdr to infos placeholders for everything but hdr
     mf = munch.Munch(pixelSize=1.0)
 
-    infos = _add_infos_header(
-        infos, commentary_hdr, mf, 1.0, "afilename", "amaskname", 1
-    )
-    captured = capfd.readouterr()
-
-    if ASTROPY_VERSION < ASTROPY_WORKING:
-        # NOTE: Adding colors codes because output with cprint has them
-        msg = (
-            "\x1b[32mCommentary cards are removed from the header with astropy"
-            f" version < {ASTROPY_WORKING}. Your astropy version is"
-            f" {ASTROPY_VERSION}\x1b[0m\n"
+    with pytest.warns(RuntimeWarning, match="Commentary cards"):
+        infos = _add_infos_header(
+            infos, commentary_hdr, mf, 1.0, "afilename", "amaskname", 1
         )
-        assert captured.out == msg
-    else:
-        assert not captured.out

--- a/amical/tests/test_extraction.py
+++ b/amical/tests/test_extraction.py
@@ -85,6 +85,6 @@ def test_no_commentary_warning_astropy_version():
 
     with pytest.warns(
         RuntimeWarning,
-        match="Commentary cards are removed from the header with astropy"
+        match="Commentary cards are removed from the header with astropy",
     ):
         infos = _add_infos_header(infos, hdr, mf, 1.0, "afilename", "amaskname", 1)

--- a/amical/tests/test_extraction.py
+++ b/amical/tests/test_extraction.py
@@ -83,8 +83,30 @@ def test_commentary_infos_drops(commentary_infos):
     assert "HISTORY" in commentary_infos.hdr
 
 
-def test_astropy_version_warning(infos, commentary_hdr):
-    # Test that AMICAL warns about astropy < 5.0 removing commentary cards
+@pytest.mark.skipif(
+    ASTROPY_VERSION >= ASTROPY_WORKING,
+    reason="There are no warnings raised for Astropy 5.0+",
+)
+def test_commentary_warning_astropy_version(infos, commentary_hdr):
+
+    # Add hdr to infos placeholders for everything but hdr
+    mf = munch.Munch(pixelSize=1.0)
+
+    with pytest.warns(RuntimeWarning, match="Commentary cards"):
+        infos = _add_infos_header(
+            infos, commentary_hdr, mf, 1.0, "afilename", "amaskname", 1
+        )
+
+
+@pytest.mark.skipif(
+    ASTROPY_VERSION < ASTROPY_WORKING,
+    reason="Astropy < 5.0 should raise a warning for commentary cards",
+)
+@pytest.mark.xfail(
+    ASTROPY_VERSION >= ASTROPY_WORKING,
+    reason="AMICAL should not raise a warning for commentary cards with astropy 5.0+",
+)
+def test_no_commentary_warning_astropy_version(infos, commentary_hdr):
 
     # Add hdr to infos placeholders for everything but hdr
     mf = munch.Munch(pixelSize=1.0)

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     matplotlib
     munch
     numpy
+    packaging>=21.0
     scipy
     termcolor
     tqdm


### PR DESCRIPTION
This is a follow-up for #60 by @neutrinoceros. As discussed there, I added a warning that commentary cards are removed. I also changed `working version` to `5.0rc1`, the first release candidate with the upstream fix included. I also added tests to 1) check that the card is included in 5.0 and 2) Check that the warning is issued before 5.0.