### PR TITLE
Use more explicit errors and warnings in data cleaning

### DIFF
--- a/amical/data_processing.py
+++ b/amical/data_processing.py
@@ -299,6 +299,7 @@ def show_clean_params(
     with fits.open(filename) as fd:
         data = fd[ihdu].data
     img0 = data[nframe]
+    dims = img0.shape
 
     # Add check to create default add_bad list (not use mutable data)
     if add_bad is None:
@@ -365,6 +366,8 @@ def show_clean_params(
         "w--",
         label="Resized image",
     )
+    plt.xlim((0, dims[0] - 1))
+    plt.ylim((0, dims[1] - 1))
     if not noBadPixel:
         if remove_bad:
             label = "Fixed hot/bad pixels"

--- a/amical/data_processing.py
+++ b/amical/data_processing.py
@@ -175,12 +175,12 @@ def select_data(cube, clip_fact=0.5, clip=False, verbose=True, display=True):
         plt.figure(figsize=(7, 7))
         plt.subplot(2, 2, 1)
         plt.title("Best fram (%i)" % best_fr)
-        plt.imshow(cube[best_fr], norm=PowerNorm(0.5), cmap="afmhot", vmin=0)
+        plt.imshow(cube[best_fr], norm=PowerNorm(0.5, vmin=0), cmap="afmhot")
         plt.subplot(2, 2, 2)
         plt.imshow(np.fft.fftshift(fft_fram[best_fr]), cmap="gist_stern")
         plt.subplot(2, 2, 3)
         plt.title("Worst fram (%i) %s" % (worst_fr, ext))
-        plt.imshow(cube[worst_fr], norm=PowerNorm(0.5), cmap="afmhot", vmin=0)
+        plt.imshow(cube[worst_fr], norm=PowerNorm(0.5, vmin=0), cmap="afmhot")
         plt.subplot(2, 2, 4)
         plt.imshow(np.fft.fftshift(fft_fram[worst_fr]), cmap="gist_stern")
         plt.tight_layout()
@@ -352,7 +352,7 @@ def show_clean_params(
     max_val = img1[y0, x0]
     fig = plt.figure(figsize=(5, 5))
     plt.title("--- CLEANING PARAMETERS ---")
-    plt.imshow(img1, norm=PowerNorm(0.5), cmap="afmhot", vmin=0, vmax=max_val)
+    plt.imshow(img1, norm=PowerNorm(0.5, vmin=0, vmax=max_val), cmap="afmhot")
     plt.plot(x1, y1, label="Inner radius for sky subtraction")
     plt.plot(x2, y2, label="Outer radius for sky subtraction")
     if apod:

--- a/amical/data_processing.py
+++ b/amical/data_processing.py
@@ -199,7 +199,7 @@ def select_data(cube, clip_fact=0.5, clip=False, verbose=True, display=True):
     return cube_cleaned_checked
 
 
-def sky_correction(imA, r1=100, dr=20):
+def sky_correction(imA, r1=100, dr=20, verbose=False):
     """
     Perform background sky correction to be as close to zero as possible.
     """
@@ -242,6 +242,12 @@ def sky_correction(imA, r1=100, dr=20):
             "Background not computed, likely because specified radius is out of bounds",
             RuntimeWarning,
         )
+    elif verbose:
+        print(
+            f"Sky correction of {backgroundB} was subtracted,"
+            f" remaining background is {backgroundC}."
+        )
+
     return imC, backgroundC
 
 
@@ -464,7 +470,7 @@ def clean_data(
         img1 = _remove_dark(img1, darkfile=darkfile, verbose=verbose)
         im_rec_max = crop_max(img1, isz, offx=offx, offy=offy, f=f_kernel)[0]
         if sky:
-            img_biased = sky_correction(im_rec_max, r1=r1, dr=dr)[0]
+            img_biased = sky_correction(im_rec_max, r1=r1, dr=dr, verbose=verbose)[0]
         else:
             img_biased = im_rec_max.copy()
         img_biased[img_biased < 0] = 0  # Remove negative pixels

--- a/amical/tests/test_processing.py
+++ b/amical/tests/test_processing.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from amical.data_processing import sky_correction
+from amical.data_processing import sky_correction, clean_data
 
 
 def test_sky_out_image():
@@ -34,3 +34,11 @@ def test_sky_inner_only():
         match="The outer radius is out of the image, using everything beyond r1 as background",
     ):
         sky_correction(img, r1=r1, dr=dr)
+
+
+def test_clean_data_no_kwargs():
+    n_im = 5
+    img_dim = 80
+    data = np.random.random((n_im, img_dim, img_dim))
+
+    clean_data(data)

--- a/amical/tests/test_processing.py
+++ b/amical/tests/test_processing.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
 
-from amical.data_processing import sky_correction, clean_data
+from amical.data_processing import clean_data
+from amical.data_processing import sky_correction
 
 
 def test_sky_out_image():

--- a/amical/tests/test_processing.py
+++ b/amical/tests/test_processing.py
@@ -36,9 +36,29 @@ def test_sky_inner_only():
         sky_correction(img, r1=r1, dr=dr)
 
 
-def test_clean_data_no_kwargs():
+def test_clean_data_none_kwargs():
+    # Test clean_data when the "main" kwargs are set to None
     n_im = 5
     img_dim = 80
     data = np.random.random((n_im, img_dim, img_dim))
 
-    clean_data(data)
+    # sky=True raises a warning by default because required kwargs are None
+    with pytest.warns(
+        RuntimeWarning,
+        match="sky is set to True, but .* set to None. Skipping sky correction",
+    ):
+        cube_clean_sky = clean_data(data)
+
+    # apod=True raises a warning by default because required kwargs are None
+    with pytest.warns(
+        RuntimeWarning,
+        match="apod is set to True, but window is None. Skipping apodisation",
+    ):
+        cube_clean_apod = clean_data(data, sky=False)
+
+    cube_clean = clean_data(data, sky=False, apod=False)
+
+    assert (data == cube_clean).all()
+    assert np.logical_and(
+        cube_clean == cube_clean_apod, cube_clean == cube_clean_sky
+    ).all()

--- a/amical/tests/test_processing.py
+++ b/amical/tests/test_processing.py
@@ -1,0 +1,35 @@
+import numpy as np
+from amical.data_processing import sky_correction
+import pytest
+
+
+def test_sky_out_image():
+    img_dim = 80
+    img = np.ones((img_dim, img_dim))
+
+    # Inner radius beyond image corners
+    r1 = np.sqrt(2 * (img_dim / 2) ** 2) + 2
+
+    with pytest.warns(
+        RuntimeWarning,
+        match="Background not computed, likely because specified radius is out of bounds",
+    ):
+        img_bg, bg = sky_correction(img, r1=r1)
+
+    assert np.all(img_bg == img)
+    assert np.all(bg == 0)
+
+
+def test_sky_inner_only():
+    img_dim = 80
+    img = np.ones((img_dim, img_dim))
+
+    # Inner radius beyond image corners
+    r1 = np.sqrt(2 * (img_dim / 2) ** 2) - 10
+    dr = 100
+
+    with pytest.warns(
+        RuntimeWarning,
+        match="The outer radius is out of the image, using everything beyond r1 as background",
+    ):
+        sky_correction(img, r1=r1, dr=dr)

--- a/amical/tests/test_tools.py
+++ b/amical/tests/test_tools.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pytest
+
+from amical import tools
+
+
+def test_crop_max():
+
+    img_size = 80  # Same size as NIRISS images
+    img = np.ones((img_size, img_size))
+    xmax, ymax = 17, 57
+    img[ymax, xmax] = img.max() * 5  # Add off-centered max pixel
+
+    # Pre-calculate expected max size
+    isz_max = 2 * np.min([xmax, img.shape[1] - xmax, ymax, img.shape[0] - ymax])
+    isz_too_big = isz_max + 1
+
+    # Using full message because we also check the suggested size
+    size_msg = (
+        f"The specified cropped image size, {isz_too_big}, is greater than the distance"
+        " to the PSF center in at least one dimension. The max size for this image is"
+        f" {isz_max}."
+    )
+    with pytest.raises(ValueError, match=size_msg):
+        # Above max size should raise the error
+        tools.crop_max(img, isz_too_big, filtmed=False)
+
+    # Setting filtmed=False because the simple image has only one pixe > 1
+    img_cropped, center_pos = tools.crop_max(img, isz_max, filtmed=False)
+
+    assert center_pos == (xmax, ymax)
+    assert img_cropped.shape[0] == isz_max
+    assert img_cropped.shape[0] == img_cropped.shape[1]

--- a/amical/tests/test_tools.py
+++ b/amical/tests/test_tools.py
@@ -12,7 +12,7 @@ def test_crop_max():
     img[ymax, xmax] = img.max() * 5  # Add off-centered max pixel
 
     # Pre-calculate expected max size
-    isz_max = 2 * np.min([xmax, img.shape[1] - xmax, ymax, img.shape[0] - ymax])
+    isz_max = 2 * np.min([xmax, img.shape[1] - xmax, ymax, img.shape[0] - ymax]) + 1
     isz_too_big = isz_max + 1
 
     # Using full message because we also check the suggested size

--- a/amical/tests/test_tools.py
+++ b/amical/tests/test_tools.py
@@ -12,7 +12,9 @@ def test_crop_max():
     img[ymax, xmax] = img.max() * 5  # Add off-centered max pixel
 
     # Pre-calculate expected max size
-    isz_max = 2 * np.min([xmax, img.shape[1] - xmax, ymax, img.shape[0] - ymax]) + 1
+    isz_max = (
+        2 * np.min([xmax, img.shape[1] - xmax - 1, ymax, img.shape[0] - ymax - 1]) + 1
+    )
     isz_too_big = isz_max + 1
 
     # Using full message because we also check the suggested size

--- a/amical/tests/test_tools.py
+++ b/amical/tests/test_tools.py
@@ -7,9 +7,9 @@ from amical import tools
 def test_crop_max():
 
     img_size = 80  # Same size as NIRISS images
-    img = np.ones((img_size, img_size))
-    xmax, ymax = 17, 57
-    img[ymax, xmax] = img.max() * 5  # Add off-centered max pixel
+    img = np.random.random((img_size, img_size))
+    xmax, ymax = np.random.randint(0, high=img_size, size=2)
+    img[ymax, xmax] = img.max() * 3 + 1  # Add max pixel at pre-determined location
 
     # Pre-calculate expected max size
     isz_max = (

--- a/amical/tests/test_tools.py
+++ b/amical/tests/test_tools.py
@@ -19,7 +19,7 @@ def test_crop_max():
     size_msg = (
         f"The specified cropped image size, {isz_too_big}, is greater than the distance"
         " to the PSF center in at least one dimension. The max size for this image is"
-        f" {isz_max}."
+        f" {isz_max}"
     )
     with pytest.raises(ValueError, match=size_msg):
         # Above max size should raise the error

--- a/amical/tools.py
+++ b/amical/tools.py
@@ -78,7 +78,9 @@ def crop_max(img, dim, offx=0, offy=0, filtmed=True, f=3):
     pos_max = np.where(im_med == im_med.max())
     X = pos_max[1][0] + offx
     Y = pos_max[0][0] + offy
-    isz_max = 2 * np.min([X, img.shape[1] - X, Y, img.shape[0] - Y]) + 1
+    isz_max = (
+        2 * np.min([X, img.shape[1] - X - 1, Y, img.shape[0] - Y - 1]) + 1
+    )
     if isz_max < dim:
         size_msg = (
             f"The specified cropped image size, {dim}, is greater than the distance to"

--- a/amical/tools.py
+++ b/amical/tools.py
@@ -78,6 +78,14 @@ def crop_max(img, dim, offx=0, offy=0, filtmed=True, f=3):
     pos_max = np.where(im_med == im_med.max())
     X = pos_max[1][0] + offx
     Y = pos_max[0][0] + offy
+    isz_max = 2 * np.min([X, img.shape[1] - X, Y, img.shape[0] - Y])
+    if isz_max < dim:
+        size_msg = (
+            f"The specified cropped image size, {dim}, is greater than the distance to"
+            " the PSF center in at least one dimension. The max size for this image is"
+            f" {isz_max}."
+        )
+        raise ValueError(size_msg)
     cutout = Cutout2D(img, (X, Y), dim)
     return cutout.data, (X, Y)
 

--- a/amical/tools.py
+++ b/amical/tools.py
@@ -78,7 +78,7 @@ def crop_max(img, dim, offx=0, offy=0, filtmed=True, f=3):
     pos_max = np.where(im_med == im_med.max())
     X = pos_max[1][0] + offx
     Y = pos_max[0][0] + offy
-    isz_max = 2 * np.min([X, img.shape[1] - X, Y, img.shape[0] - Y])
+    isz_max = 2 * np.min([X, img.shape[1] - X, Y, img.shape[0] - Y]) + 1
     if isz_max < dim:
         size_msg = (
             f"The specified cropped image size, {dim}, is greater than the distance to"

--- a/amical/tools.py
+++ b/amical/tools.py
@@ -78,9 +78,7 @@ def crop_max(img, dim, offx=0, offy=0, filtmed=True, f=3):
     pos_max = np.where(im_med == im_med.max())
     X = pos_max[1][0] + offx
     Y = pos_max[0][0] + offy
-    isz_max = (
-        2 * np.min([X, img.shape[1] - X - 1, Y, img.shape[0] - Y - 1]) + 1
-    )
+    isz_max = 2 * np.min([X, img.shape[1] - X - 1, Y, img.shape[0] - Y - 1]) + 1
     if isz_max < dim:
         size_msg = (
             f"The specified cropped image size, {dim}, is greater than the distance to"

--- a/amical/tools.py
+++ b/amical/tools.py
@@ -83,7 +83,7 @@ def crop_max(img, dim, offx=0, offy=0, filtmed=True, f=3):
         size_msg = (
             f"The specified cropped image size, {dim}, is greater than the distance to"
             " the PSF center in at least one dimension. The max size for this image is"
-            f" {isz_max}."
+            f" {isz_max}"
         )
         raise ValueError(size_msg)
     cutout = Cutout2D(img, (X, Y), dim)


### PR DESCRIPTION
When playing with simulated NIRISS data, I encountered a few corner cases during the cleaning due to the small size (80x80) of the images. The problems were not caught and resulted in error later when the image was re-used:
- Using an `isz` that went out of bounds gave a non-square array and did not warn the user. After discussing with @DrSoulain, we chose to simply raise and error and suggest maximum possible value to the user.
- Using a sky subtraction (inner) radius that was out of the image was not caught and resulted in a `NaN` value for the whole background. Now, there is a warning and the background subraction is skipped (same behaviour as the previous one if an `IndexError` was caught.
- I also added a warning if the outer sky subtraction radius is out of bounds, to let the user know that the outer radius does not restrict the background and that everything beyond `r1` is used.

I also added tests for these changes in two new files `test_processing.py` and `test_tools.py`.