### PR TITLE
Per-frame bad pixel correction

### DIFF
--- a/amical/data_processing.py
+++ b/amical/data_processing.py
@@ -466,7 +466,8 @@ def clean_data(
     l_bad_frame = []
 
     # Add check to create default add_bad list (not use mutable data)
-    if add_bad is None:
+    if add_bad is None or len(add_bad) == 0:
+        # Reshape add_bad to simplify indexing in loop
         add_bad = [
             [],
         ] * n_im

--- a/amical/data_processing.py
+++ b/amical/data_processing.py
@@ -14,16 +14,14 @@ import sys
 import warnings
 
 import numpy as np
-from astropy.convolution import Gaussian2DKernel
-from astropy.convolution import interpolate_replace_nans
+from astropy.convolution import Gaussian2DKernel, interpolate_replace_nans
 from astropy.io import fits
 from matplotlib import pyplot as plt
 from matplotlib.colors import PowerNorm
 from termcolor import cprint
 from tqdm import tqdm
 
-from amical.tools import apply_windowing
-from amical.tools import crop_max
+from amical.tools import apply_windowing, crop_max
 
 
 def _apply_patch_ghost(cube, xc, yc, radius=20, dx=0, dy=-200, method="bg"):
@@ -260,6 +258,7 @@ def fix_bad_pixels(image, bad_map, add_bad=None, x_stddev=1):
         add_bad = []
 
     if len(add_bad) != 0:
+        bad_map = bad_map.copy()  # Don't modify input bad pixel map, use a copy
         for j in range(len(add_bad)):
             bad_map[add_bad[j][1], add_bad[j][0]] = 1
 

--- a/amical/data_processing.py
+++ b/amical/data_processing.py
@@ -467,7 +467,13 @@ def clean_data(
 
     # Add check to create default add_bad list (not use mutable data)
     if add_bad is None:
-        add_bad = []
+        add_bad = [
+            [],
+        ] * n_im
+    else:
+        add_bad = np.array(add_bad)
+        if add_bad.ndim == 2:
+            add_bad = np.repeat(add_bad[np.newaxis, :], n_im, axis=0)
 
     if (bad_map is None) and (len(add_bad) != 0):
         # If we have extra bad pixels, define bad_map with same shape as image
@@ -491,7 +497,7 @@ def clean_data(
         img0 = data[i]
         img0 = _apply_edge_correction(img0, edge=edge)
         if bad_map is not None:
-            img1 = fix_bad_pixels(img0, bad_map[i], add_bad=add_bad)
+            img1 = fix_bad_pixels(img0, bad_map[i], add_bad=add_bad[i])
         else:
             img1 = img0.copy()
 

--- a/amical/data_processing.py
+++ b/amical/data_processing.py
@@ -469,9 +469,16 @@ def clean_data(
     if add_bad is None:
         add_bad = []
 
-    # If we have extra bad pixels, define bad_map with same shape as image
     if (bad_map is None) and (len(add_bad) != 0):
+        # If we have extra bad pixels, define bad_map with same shape as image
         bad_map = np.zeros(data.shape[1:])
+    elif bad_map is not None:
+        # Shape should match data
+        if bad_map.shape != data[0].shape:
+            raise ValueError(
+                f"bad_map should have the same shape as a frame ({data[0].shape}),"
+                f" but has shape {bad_map.shape}"
+            )
 
     for i in tqdm(range(n_im), ncols=100, desc="Cleaning", leave=False):
         img0 = data[i]

--- a/amical/data_processing.py
+++ b/amical/data_processing.py
@@ -472,8 +472,11 @@ def clean_data(
         ] * n_im
     else:
         add_bad = np.array(add_bad)
-        if add_bad.ndim == 2:
+        if add_bad.ndim == 2 and len(add_bad[0]) != 0:
             add_bad = np.repeat(add_bad[np.newaxis, :], n_im, axis=0)
+        elif add_bad.ndim == 3:
+            if add_bad.shape[0] != n_im:
+                raise ValueError("3D add_bad should have one list per frame")
 
     if (bad_map is None) and (len(add_bad) != 0):
         # If we have extra bad pixels, define bad_map with same shape as image

--- a/amical/data_processing.py
+++ b/amical/data_processing.py
@@ -14,14 +14,16 @@ import sys
 import warnings
 
 import numpy as np
-from astropy.convolution import Gaussian2DKernel, interpolate_replace_nans
+from astropy.convolution import Gaussian2DKernel
+from astropy.convolution import interpolate_replace_nans
 from astropy.io import fits
 from matplotlib import pyplot as plt
 from matplotlib.colors import PowerNorm
 from termcolor import cprint
 from tqdm import tqdm
 
-from amical.tools import apply_windowing, crop_max
+from amical.tools import apply_windowing
+from amical.tools import crop_max
 
 
 def _apply_patch_ghost(cube, xc, yc, radius=20, dx=0, dy=-200, method="bg"):

--- a/amical/data_processing.py
+++ b/amical/data_processing.py
@@ -468,6 +468,10 @@ def clean_data(
     if add_bad is None:
         add_bad = []
 
+    # If we have extra bad pixels, define bad_map with same shape as image
+    if (bad_map is None) and (len(add_bad) != 0):
+        bad_map = np.zeros(data.shape[1:])
+
     for i in tqdm(range(n_im), ncols=100, desc="Cleaning", leave=False):
         img0 = data[i]
         img0 = _apply_edge_correction(img0, edge=edge)

--- a/amical/tests/test_processing.py
+++ b/amical/tests/test_processing.py
@@ -203,3 +203,16 @@ def test_clean_data_bmap_add_bad_2d():
     assert np.all([cleaned[i] == nobpix_list[i] for i in range(data.shape[0])])
     assert np.all(cleaned[:, full_bad_map] != data[:, full_bad_map])
     assert np.all(cleaned[:, ~full_bad_map] == data[:, ~full_bad_map])
+
+
+def test_clean_data_bmap_2d_shape():
+    n_im = 5
+    img_dim = 80
+    data = np.random.random((n_im, img_dim, img_dim))
+
+    bad_map = np.zeros((img_dim, img_dim - 1), dtype=bool)
+
+    with pytest.raises(
+        ValueError, match="bad_map should have the same shape as a frame"
+    ):
+        clean_data(data, sky=False, apod=False, bad_map=bad_map)

--- a/amical/tests/test_processing.py
+++ b/amical/tests/test_processing.py
@@ -3,6 +3,7 @@ import pytest
 from matplotlib import pyplot as plt
 
 import amical
+from amical.data_processing import _get_3d_bad_pixels
 from amical.data_processing import clean_data
 from amical.data_processing import fix_bad_pixels
 from amical.data_processing import sky_correction
@@ -354,7 +355,7 @@ def test_clean_data_bmap_add_bad_3d():
     assert np.all(cleaned[~full_bad_cube] == data[~full_bad_cube])
 
 
-def test_clean_data_add_bad_3d_shape():
+def test_3d_bad_pix_abad_3d_shape():
     # Test combination of 3d bad pixels with add_bad 3d as well
     n_im = 5
     img_dim = 80
@@ -365,4 +366,32 @@ def test_clean_data_add_bad_3d_shape():
     ] * (n_im + 1)
 
     with pytest.raises(ValueError, match="3D add_bad should have one list per frame"):
-        clean_data(data, sky=False, apod=False, add_bad=add_bad)
+        _get_3d_bad_pixels(None, add_bad, data)
+
+
+def test_3d_bad_pix_bmap_2d_shape():
+    # Assert that bad shape raises error in 2d
+    n_im = 5
+    img_dim = 80
+    data = np.random.random((n_im, img_dim, img_dim))
+
+    bad_map = np.zeros((img_dim, img_dim - 1), dtype=bool)
+
+    with pytest.raises(
+        ValueError, match="2D bad_map should have the same shape as a frame"
+    ):
+        _get_3d_bad_pixels(bad_map, None, data)
+
+
+def test_3d_bad_pix_bmap_3d_shape():
+    # Assert that bad shape raises error in 3d
+    n_im = 5
+    img_dim = 80
+    data = np.random.random((n_im, img_dim, img_dim))
+
+    bad_map = np.zeros((n_im, img_dim, img_dim - 1), dtype=bool)
+
+    with pytest.raises(
+        ValueError, match="3D bad_map should have the same shape as data cube"
+    ):
+        _get_3d_bad_pixels(bad_map, None, data)

--- a/amical/tests/test_processing.py
+++ b/amical/tests/test_processing.py
@@ -4,6 +4,7 @@ from matplotlib import pyplot as plt
 
 import amical
 from amical.data_processing import clean_data
+from amical.data_processing import fix_bad_pixels
 from amical.data_processing import sky_correction
 
 
@@ -105,3 +106,100 @@ def test_clean(global_datadir):
     assert type(cube_clean) == np.ndarray
     assert im1.shape == cube_clean.shape
     assert im2.shape == cube_clean.shape
+
+
+def test_fix_bad_pixel_no_bad():
+    img_dim = 80
+    data = np.random.random((img_dim, img_dim))
+
+    no_bpix = fix_bad_pixels(data, np.zeros_like(data, dtype=bool))
+
+    assert np.all(data == no_bpix)
+
+
+def test_fix_one_bad_pixel():
+
+    img_dim = 80
+    data = np.random.random((img_dim, img_dim))
+
+    bad_ind = tuple(np.random.randint(0, high=img_dim, size=2))
+    data[bad_ind] = 1e5
+
+    bad_map = np.zeros_like(data, dtype=bool)
+    bad_map[bad_ind] = 1
+
+    no_bpix = fix_bad_pixels(data, bad_map)
+
+    assert no_bpix[bad_map] != data[bad_map]
+    assert np.all(no_bpix[~bad_map] == data[~bad_map])
+    assert 0.0 <= no_bpix[bad_ind] <= 1.0  # Because test data is random U(0, 1)
+
+
+@pytest.mark.usefixtures("close_figures")
+def test_clean_data_no_bmap_add_bad():
+    n_im = 5
+    img_dim = 80
+    data = np.random.random((n_im, img_dim, img_dim))
+
+    bad_ind = tuple(np.random.randint(0, high=img_dim, size=2))
+    bad_ind_3d = (slice(None),) + bad_ind
+    add_bad = [bad_ind[::-1]]
+
+    # Put value out of data bounds (0, 1) to make sure corrected != original
+    data[bad_ind_3d] = 1e5
+
+    # Test case with non-emtpy add_bad but empty add_bad
+    cleaned = clean_data(data, sky=False, apod=False, add_bad=add_bad)
+    nobpix_list = [
+        fix_bad_pixels(img, bad_map=np.zeros((img_dim, img_dim)), add_bad=add_bad)
+        for img in data
+    ]
+
+    assert np.all([cleaned[i] == nobpix_list[i] for i in range(data.shape[0])])
+    assert np.all(cleaned[bad_ind_3d] != data[bad_ind_3d])
+
+
+@pytest.mark.usefixtures("close_figures")
+def test_clean_data_bmap_2d():
+    n_im = 5
+    img_dim = 80
+    data = np.random.random((n_im, img_dim, img_dim))
+
+    bad_map = np.zeros((img_dim, img_dim), dtype=bool)
+    bad_map[tuple(np.random.randint(0, high=img_dim, size=2))] = 1
+
+    data[:, bad_map] = 1e5
+
+    # Test case with non-emtpy add_bad but empty add_bad
+    cleaned = clean_data(data, sky=False, apod=False, bad_map=bad_map)
+    nobpix_list = [fix_bad_pixels(img, bad_map=bad_map) for img in data]
+
+    assert np.all([cleaned[i] == nobpix_list[i] for i in range(data.shape[0])])
+    assert np.all(cleaned[:, bad_map] != data[:, bad_map])
+    assert np.all(cleaned[:, ~bad_map] == data[:, ~bad_map])
+
+
+@pytest.mark.usefixtures("close_figures")
+def test_clean_data_bmap_add_bad_2d():
+    n_im = 5
+    img_dim = 80
+    data = np.random.random((n_im, img_dim, img_dim))
+
+    new_bad_ind = tuple(np.random.randint(0, high=img_dim, size=2))
+    add_bad = [new_bad_ind[::-1]]
+
+    bad_map = np.zeros((img_dim, img_dim), dtype=bool)
+    bad_map[tuple(np.random.randint(0, high=img_dim, size=2))] = 1
+
+    # Test case with non-emtpy add_bad but empty add_bad
+    cleaned = clean_data(data, sky=False, apod=False, bad_map=bad_map, add_bad=add_bad)
+    nobpix_list = [
+        fix_bad_pixels(img, bad_map=bad_map, add_bad=add_bad) for img in data
+    ]
+
+    full_bad_map = bad_map.copy()
+    full_bad_map[new_bad_ind] = True
+
+    assert np.all([cleaned[i] == nobpix_list[i] for i in range(data.shape[0])])
+    assert np.all(cleaned[:, full_bad_map] != data[:, full_bad_map])
+    assert np.all(cleaned[:, ~full_bad_map] == data[:, ~full_bad_map])

--- a/amical/tests/test_processing.py
+++ b/amical/tests/test_processing.py
@@ -137,27 +137,6 @@ def test_fix_one_bad_pixel():
 
 
 @pytest.mark.usefixtures("close_figures")
-def test_clean_data_bmap_2d():
-    # Test regular 2d bad pixel map
-    n_im = 5
-    img_dim = 80
-    data = np.random.random((n_im, img_dim, img_dim))
-
-    bad_map = np.zeros((img_dim, img_dim), dtype=bool)
-    bad_map[tuple(np.random.randint(0, high=img_dim, size=2))] = 1
-
-    # Set values out of random range to test that they did change later
-    data[:, bad_map] = 1e5
-
-    cleaned = clean_data(data, sky=False, apod=False, bad_map=bad_map)
-    nobpix_list = [fix_bad_pixels(img, bad_map=bad_map) for img in data]
-
-    assert np.all([cleaned[i] == nobpix_list[i] for i in range(data.shape[0])])
-    assert np.all(cleaned[:, bad_map] != data[:, bad_map])
-    assert np.all(cleaned[:, ~bad_map] == data[:, ~bad_map])
-
-
-@pytest.mark.usefixtures("close_figures")
 def test_clean_data_no_bmap_add_bad():
     # Test add_data kwarg when no bad_map
     n_im = 5

--- a/amical/tests/test_processing.py
+++ b/amical/tests/test_processing.py
@@ -352,3 +352,17 @@ def test_clean_data_bmap_add_bad_3d():
     assert np.all([cleaned[i] == nobpix_list[i] for i in range(data.shape[0])])
     assert np.all(cleaned[full_bad_cube] != data[full_bad_cube])
     assert np.all(cleaned[~full_bad_cube] == data[~full_bad_cube])
+
+
+def test_clean_data_add_bad_3d_shape():
+    # Test combination of 3d bad pixels with add_bad 3d as well
+    n_im = 5
+    img_dim = 80
+    data = np.random.random((n_im, img_dim, img_dim))
+
+    add_bad = [
+        [(1, 2)],
+    ] * (n_im + 1)
+
+    with pytest.raises(ValueError, match="3D add_bad should have one list per frame"):
+        clean_data(data, sky=False, apod=False, add_bad=add_bad)


### PR DESCRIPTION
This would allow setting the bad pixel map or the `add_bad` list separately for each frame (fixes #81). I am making it it a draft until #76 is merged, but I'm open to suggestions in the meantime. The changes are compatible with the previous 2d-only behaviour, simply making 3d arrays an extra option. Short summary of changes:

- Bad pixel map `bad_map` can now be either a 2d array with one map for all frames or 3d array with one map per frame
- `add_bad` can now either be a list of bad pixel index pairs (e.g. `[(1,2), (2, 3)]`) applied to all frames, or a list of such lists (with total length equal to the number of frames). (2d and 3d arrays work as well)
- There are tests for `fix_bad_pixels()` and `clean_data()` (mainly for the bad pixel correction aspect).