### PR TITLE
Subtract sky from full image and allow arbitrary mask

### DIFF
--- a/amical/data_processing.py
+++ b/amical/data_processing.py
@@ -568,10 +568,10 @@ def clean_data(
             # Get expected center for sky correction
             filtmed = f_kernel is not None
             im_rec_max = crop_max(
-                img1, isz, offx=offx, offy=offy, filtmed=filtmed, f=f_kernel
+                img_biased, isz, offx=offx, offy=offy, filtmed=filtmed, f=f_kernel
             )[0]
         else:
-            im_rec_max = img1.copy()
+            im_rec_max = img_biased.copy()
 
         if (
             (im_rec_max.shape[0] != im_rec_max.shape[1])

--- a/amical/data_processing.py
+++ b/amical/data_processing.py
@@ -200,12 +200,15 @@ def select_data(cube, clip_fact=0.5, clip=False, verbose=True, display=True):
     return cube_cleaned_checked
 
 
-def sky_correction(imA, r1=100, dr=20, verbose=False):
+def sky_correction(imA, r1=100, dr=20, verbose=False, *, center=None):
     """
     Perform background sky correction to be as close to zero as possible.
     """
     isz = imA.shape[0]
-    xc, yc = isz // 2, isz // 2
+    if center is None:
+        xc, yc = isz // 2, isz // 2
+    else:
+        xc, yc = center
     xx, yy = np.arange(isz), np.arange(isz)
     xx2 = xx - xc
     yy2 = yc - yy

--- a/amical/data_processing.py
+++ b/amical/data_processing.py
@@ -403,15 +403,15 @@ def show_clean_params(
     else:
         noBadPixel = True
 
-    r2 = r1 + dr
     theta = np.linspace(0, 2 * np.pi, 100)
     x0 = pos[0]
     y0 = pos[1]
-
     x1 = r1 * np.cos(theta) + x0
     y1 = r1 * np.sin(theta) + y0
-    x2 = r2 * np.cos(theta) + x0
-    y2 = r2 * np.sin(theta) + y0
+    if dr is not None:
+        r2 = r1 + dr
+        x2 = r2 * np.cos(theta) + x0
+        y2 = r2 * np.sin(theta) + y0
     if window is not None:
         r3 = window
         x3 = r3 * np.cos(theta) + x0
@@ -426,8 +426,11 @@ def show_clean_params(
     fig = plt.figure(figsize=(5, 5))
     plt.title("--- CLEANING PARAMETERS ---")
     plt.imshow(img1, norm=PowerNorm(0.5, vmin=0, vmax=max_val), cmap="afmhot")
-    plt.plot(x1, y1, label="Inner radius for sky subtraction")
-    plt.plot(x2, y2, label="Outer radius for sky subtraction")
+    if dr is not None:
+        plt.plot(x1, y1, label="Inner radius for sky subtraction")
+        plt.plot(x2, y2, label="Outer radius for sky subtraction")
+    else:
+        plt.plot(x1, y1, label="Boundary for sky subtraction")
     if apod:
         if window is not None:
             plt.plot(x3, y3, "--", label="Super-gaussian windowing")

--- a/amical/data_processing.py
+++ b/amical/data_processing.py
@@ -543,7 +543,7 @@ def clean_data(
         else:
             center = None
 
-        if sky and dr is not None and r1 is not None:
+        if sky and r1 is not None:
             img_biased = sky_correction(
                 img1, r1=r1, dr=dr, verbose=verbose, center=center
             )[0]
@@ -552,8 +552,6 @@ def clean_data(
                 none_kwarg = "r1 and dr are"
             elif r1 is None:
                 none_kwarg = "r1 is"
-            elif dr is None:
-                none_kwarg = "dr is"
             warnings.warn(
                 f"sky is set to True, but {none_kwarg} set to None. Skipping sky correction",
                 RuntimeWarning,

--- a/amical/data_processing.py
+++ b/amical/data_processing.py
@@ -24,6 +24,7 @@ from tqdm import tqdm
 
 from amical.tools import apply_windowing
 from amical.tools import crop_max
+from amical.tools import find_max
 
 
 def _apply_patch_ghost(cube, xc, yc, radius=20, dx=0, dy=-200, method="bg"):
@@ -593,9 +594,7 @@ def clean_data(
         if isz is not None:
             # Get expected center for sky correction
             filtmed = f_kernel is not None
-            center = crop_max(
-                img1, isz, offx=offx, offy=offy, filtmed=filtmed, f=f_kernel
-            )[1]
+            center = find_max(img1, filtmed=filtmed, f=f_kernel)
         else:
             center = None
 

--- a/amical/data_processing.py
+++ b/amical/data_processing.py
@@ -212,17 +212,20 @@ def sky_correction(imA, r1=100, dr=20, verbose=False, *, center=None):
     xx, yy = np.arange(isz), np.arange(isz)
     xx2 = xx - xc
     yy2 = yc - yy
-    r2 = r1 + dr
 
     distance = np.sqrt(xx2 ** 2 + yy2[:, np.newaxis] ** 2)
     inner_cond = r1 <= distance
-    outer_cond = distance <= r2
+    if dr is not None:
+        r2 = r1 + dr
+        outer_cond = distance <= r2
+    else:
+        outer_cond = True
     cond_bg = inner_cond & outer_cond
 
     do_bg = True
     if not cond_bg.any():
         do_bg = False
-    elif outer_cond.all():
+    elif dr is not None and np.all(outer_cond):
         warnings.warn(
             "The outer radius is out of the image, using everything beyond r1 as background",
             RuntimeWarning,

--- a/amical/tests/test_processing.py
+++ b/amical/tests/test_processing.py
@@ -175,7 +175,7 @@ def test_clean_data_none_kwargs():
     # sky=True raises a warning by default because required kwargs are None
     with pytest.warns(
         RuntimeWarning,
-        match="sky is set to True, but .* set to None. Skipping sky correction",
+        match="sky is set to True, but r1 and mask are set to None. Skipping sky correction",
     ):
         cube_clean_sky = clean_data(data)
 

--- a/amical/tests/test_processing.py
+++ b/amical/tests/test_processing.py
@@ -83,7 +83,6 @@ def test_sky_dr_none():
     sky_correction(img, r1=r1, dr=dr)
 
 
-@pytest.mark.usefixtures("close_figures")
 def test_sky_correction_mask_all():
     # Check that full correction mask gives expected result
     img_dim = 80

--- a/amical/tests/test_processing.py
+++ b/amical/tests/test_processing.py
@@ -150,6 +150,17 @@ def test_fix_bad_pixel_no_bad():
     assert np.all(data == no_bpix)
 
 
+def test_clean_data_dr_none():
+    # Test clean_data with dr=None (i.e. single sky delimiter)
+    n_im = 5
+    img_dim = 80
+    data = np.random.random((n_im, img_dim, img_dim))
+
+    r1 = int(np.sqrt(2 * (img_dim / 2) ** 2) - 2)  # working r1
+
+    clean_data(data, r1=r1, apod=False)
+
+
 def test_fix_one_bad_pixel():
 
     img_dim = 80

--- a/amical/tests/test_processing.py
+++ b/amical/tests/test_processing.py
@@ -69,6 +69,19 @@ def test_clean_sky_out_crop():
 
 
 @pytest.mark.usefixtures("close_figures")
+def test_sky_dr_none():
+    # Make sure dr=None does not crash
+    img_dim = 80
+    img = np.ones((img_dim, img_dim))
+
+    # Outer radius beyond image corners
+    r1 = np.sqrt(2 * (img_dim / 2) ** 2) - 10
+    dr = None
+
+    sky_correction(img, r1=r1, dr=dr)
+
+
+@pytest.mark.usefixtures("close_figures")
 def test_clean_data_none_kwargs():
     # Test clean_data when the "main" kwargs are set to None
     n_im = 5

--- a/amical/tests/test_processing.py
+++ b/amical/tests/test_processing.py
@@ -38,7 +38,7 @@ def test_sky_inner_only():
     img_dim = 80
     img = np.ones((img_dim, img_dim))
 
-    # Inner radius beyond image corners
+    # Outer radius beyond image corners
     r1 = np.sqrt(2 * (img_dim / 2) ** 2) - 10
     dr = 100
 
@@ -47,6 +47,25 @@ def test_sky_inner_only():
         match="The outer radius is out of the image, using everything beyond r1 as background",
     ):
         sky_correction(img, r1=r1, dr=dr)
+
+
+@pytest.mark.usefixtures("close_figures")
+def test_clean_sky_out_crop():
+
+    n_im = 5
+    img_dim = 80
+    data = np.ones((n_im, img_dim, img_dim))
+    xmax, ymax = (40, 41)
+    data[:, ymax, xmax] = data.max() * 3 + 1  # Add max pixel at pre-determined location
+
+    isz = 67
+
+    r1 = int(np.sqrt(2 * (isz / 2) ** 2) + 2)
+
+    clean_cube = clean_data(data, isz=isz, r1=r1, dr=2, f_kernel=None, apod=False)
+
+    # Make sure did not just remove everything
+    assert len(clean_cube) != 0
 
 
 @pytest.mark.usefixtures("close_figures")

--- a/amical/tests/test_tools.py
+++ b/amical/tests/test_tools.py
@@ -5,6 +5,17 @@ from astropy.io import fits
 from amical import tools
 
 
+def test_find_max():
+    img_size = 80  # Same size as NIRISS images
+    img = np.random.random((img_size, img_size))
+    xmax, ymax = np.random.randint(0, high=img_size, size=2)
+    img[ymax, xmax] = img.max() * 3 + 1  # Add max pixel at pre-determined location
+
+    center_pos = tools.find_max(img, filtmed=False)
+
+    assert center_pos == (xmax, ymax)
+
+
 def test_crop_max():
 
     img_size = 80  # Same size as NIRISS images

--- a/amical/tools.py
+++ b/amical/tools.py
@@ -42,6 +42,45 @@ def rad2mas(rad):
     return mas
 
 
+def find_max(img, filtmed=True, f=3):
+    """
+    Summary
+    -------------
+    Find brightest pixel of an image
+
+    Parameters
+    ----------
+    `img` : {numpy.array}
+        input image,\n
+    `filtmed` : {boolean}, (optionnal)
+        True if perform a median filter on the image (to blur bad pixels),\n
+    `f` : {float}, (optionnal),
+        If filtmed == True, kernel size of the median filter.
+
+
+    Returns
+    -------
+    `Max coordinates`: {tuple}
+        X and Y positions of max pixel
+    """
+
+    if filtmed:
+        try:
+            im_med = medfilt2d(img, f)
+        except ValueError:
+            img = img.astype(float)
+            im_med = medfilt2d(img, f)
+    else:
+        im_med = img.copy()
+
+    pos_max = np.where(im_med == im_med.max())
+
+    X = pos_max[1][0]
+    Y = pos_max[0][0]
+
+    return X, Y
+
+
 def crop_max(img, dim, offx=0, offy=0, filtmed=True, f=3):
     """
     Summary
@@ -65,18 +104,10 @@ def crop_max(img, dim, offx=0, offy=0, filtmed=True, f=3):
     `cutout`: {numpy.array}
         Resized image.
     """
-    if filtmed:
-        try:
-            im_med = medfilt2d(img, f)
-        except ValueError:
-            img = img.astype(float)
-            im_med = medfilt2d(img, f)
-    else:
-        im_med = img.copy()
+    xmax, ymax = find_max(img, filtmed=filtmed, f=f)
 
-    pos_max = np.where(im_med == im_med.max())
-    X = pos_max[1][0] + offx
-    Y = pos_max[0][0] + offy
+    X = xmax + offx
+    Y = ymax + offy
     isz_max = 2 * np.min([X, img.shape[1] - X - 1, Y, img.shape[0] - Y - 1]) + 1
     if isz_max < dim:
         size_msg = (


### PR DESCRIPTION
This adds the features described in #80. Namely:
- It changes the order of `crop_max()`and `sky_correction()` calls in `clean_data`, making the whole (non-cropped) image available for background subtraction (and not changing the default behaviour if `r1`and `dr`are within the cropped image. The center is still found before subtraction, to center the ring around the center.
- It adds an optional `mask` option in sky correction. This allows users to provide a boolean mask to use any combination of pixels for the background subtraction. Having two options (`r1` and `dr` or `mask`) for sky correction, it seemed safer to set them all to None and force user to explicitly specify the parameters. I added deprecation warnings and made the functions fall back to the default for now when no parameters are specified. Even without `mask`, forcing users to specify `r1` and `dr` seems reasonable given the various instruments (and hence various image sizes) AMICAL can be used with.