### PR TITLE
MNT: add explicit support for Python 3.10

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -29,8 +29,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        # we cannot use Python 3.10 for now, h5py (inherited dependency) isn't ready
-        python-version: '3.9'
+        python-version: '3.10'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           '3.7',
           '3.8',
           '3.9',
+          '3.10',
         ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,12 +18,12 @@ repos:
       - id: no-commit-to-branch
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.17.0
+    rev: v1.20.0
     hooks:
       - id: setup-cfg-fmt
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.11.0
+    rev: v1.12.0
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==21.6b0]
@@ -34,7 +34,7 @@ repos:
         - id: remove-tabs
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.0
+    rev: v2.29.1
     hooks:
     - id: pyupgrade
       args: [--py37-plus]
@@ -46,14 +46,14 @@ repos:
 
 
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 21.11b1
     hooks:
       - id: black
         language_version: python3
 
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
       - id: flake8
         additional_dependencies : [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ filterwarnings = [
     "ignore:the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses:DeprecationWarning",
     # the deprecation warning message for imp changed in Python 3.10, so we ignore both versions
     "ignore:the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses:DeprecationWarning",
+    # this warning is emmited from astropy 5.0, it needs to be fixed upstream
+    "ignore:The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives:DeprecationWarning"
 ]
 
 [tool.coverage.run]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering :: Astronomy
 
 [options]


### PR DESCRIPTION
Astropy just released wheels for Python 3.10, as did h5py earlier this week, so I think it should be trivial now to declare support for Python 3.10 on AMICAL