### PR TITLE
TST: fixup deprecated import statement from scipy

### DIFF
--- a/amical/externals/pymask/cpo.py
+++ b/amical/externals/pymask/cpo.py
@@ -4,7 +4,7 @@ import logging
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy
-from scipy.io.idl import readsav
+from scipy.io import readsav
 from termcolor import cprint
 
 from . import oifits


### PR DESCRIPTION
This should finish fixing bleeding-edge CI, see error : https://github.com/SydneyAstrophotonicInstrumentationLab/AMICAL/runs/4353954995?check_suite_focus=true

I've checked that this works for every version of scipy we supposedly support (it worked on scipy 1.0, which didn't have wheels for Python 3.7 so it's already older than what we need to support)