### PR TITLE
Add multiprocessing test used in smartfit

### DIFF
--- a/amical/tests/test_analysis.py
+++ b/amical/tests/test_analysis.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 import pytest
 from matplotlib import pyplot as plt
@@ -259,6 +261,7 @@ def test_pymask_oifits_no_date_obs(example_oifits_no_date_obs):
     assert isinstance(o, pymask.oifits.oifits)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 @pytest.mark.usefixtures("close_figures")
 @pytest.mark.parametrize("multiproc", [False, True])
 def test_smartfit(example_oifits, multiproc):

--- a/amical/tests/test_analysis.py
+++ b/amical/tests/test_analysis.py
@@ -260,7 +260,7 @@ def test_pymask_oifits_no_date_obs(example_oifits_no_date_obs):
 
 
 @pytest.mark.usefixtures("close_figures")
-@pytest.mark.parametrize("multiproc", [False])
+@pytest.mark.parametrize("multiproc", [False, True])
 def test_smartfit(example_oifits, multiproc):
     obs = fits2obs(example_oifits)
 

--- a/amical/tests/test_analysis.py
+++ b/amical/tests/test_analysis.py
@@ -261,7 +261,9 @@ def test_pymask_oifits_no_date_obs(example_oifits_no_date_obs):
     assert isinstance(o, pymask.oifits.oifits)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+@pytest.mark.skipif(
+    sys.platform.lower().startswith("win"), reason="does not run on windows"
+)
 @pytest.mark.usefixtures("close_figures")
 @pytest.mark.parametrize("multiproc", [False, True])
 def test_smartfit(example_oifits, multiproc):


### PR DESCRIPTION
Bug: the multiprocessing option of smartfit function is not supported on windows platform (we should skip the test for windows only, to keep testing this feature on other platform).