### PR TITLE
TST: revert a temporary workaround in GH workflows

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -49,10 +49,8 @@ jobs:
         python -m pip install -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy
 
     - name: Build amical
-      # restricting to pip<22.0 because of pyvo
-      # see https://github.com/astropy/pyvo/issues/296
       run: |
-        python -m pip install --upgrade "pip < 22.0"
+        python -m pip install --upgrade pip
         python -m pip install .[dev] --no-build-isolation
 
     - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup package
-      # restricting to pip<22.0 because of pyvo
-      # see https://github.com/astropy/pyvo/issues/296
       run: |
-        python -m pip install --upgrade "pip < 22.0"
+        python -m pip install --upgrade pip
         python -m pip install .[dev]
     - name: Run tests
       run: |

--- a/.github/workflows/type-checking.yaml
+++ b/.github/workflows/type-checking.yaml
@@ -26,10 +26,8 @@ jobs:
         python-version: '3.10'
 
     - name: Build AMICAL + type check deps
-      # restricting to pip<22.0 because of pyvo
-      # see https://github.com/astropy/pyvo/issues/296
       run: |
-        python -m pip install --upgrade "pip < 22.0"
+        python -m pip install --upgrade pip
         python -m pip install .[typecheck]
 
     - name: Run mypy


### PR DESCRIPTION
Pyvo maintainers just uploaded some wheels to PyPI, which should resolve the installation issue we faced recently.

See https://github.com/astropy/pyvo/issues/296