### PR TITLE
Add quiet mode in extraction step

### DIFF
--- a/amical/mf_pipeline/bispect.py
+++ b/amical/mf_pipeline/bispect.py
@@ -56,6 +56,7 @@ def _compute_complex_bs(
     dark_ps=None,
     closing_tri_pix=None,
     bs_multi_tri=False,
+    verbose=True,
 ):
     """Compute the complex visibilities and the bispectrum of an input ft_arr (_construct_ft_arr()).
     In addition, compute the phase phs of each frames, and some calibration array (relative to the
@@ -122,6 +123,7 @@ def _compute_complex_bs(
         desc="Extracting in the cube",
         leave=False,
         file=sys.stdout,
+        disable=np.invert(verbose),
     ):
         ft_frame = ft_arr[i]
         ps = np.abs(ft_frame) ** 2
@@ -646,13 +648,15 @@ def _compute_bs_cov(bs_arr, bs, bscov2bs_ix, n_cov):
     return bs_cov
 
 
-def _compute_cp_cov(bs_arr, bs, index_mask):
+def _compute_cp_cov(bs_arr, bs, index_mask, disable=False):
     """Compute the covariance matrix of the closure phase."""
     n_ps = bs_arr.shape[0]
     n_bispect = index_mask.n_bispect
 
     cp_cov = dblarr(n_bispect, n_bispect)
-    for i in tqdm(range(n_bispect), desc="CP covariance", ncols=100, leave=False):
+    for i in tqdm(
+        range(n_bispect), desc="CP covariance", ncols=100, leave=False, disable=disable
+    ):
         for j in range(n_bispect):
             temp1 = (bs_arr[:, i] - bs[i]) * np.conj(bs[i])
             temp2 = (bs_arr[:, j] - bs[j]) * np.conj(bs[j])
@@ -1261,6 +1265,7 @@ def extract_bs(
         dark_ps=None,
         closing_tri_pix=closing_tri_pix,
         bs_multi_tri=bs_multi_tri,
+        verbose=verbose,
     )
 
     cvis_arr = complex_bs["vis_arr"]["complex"]
@@ -1291,7 +1296,9 @@ def extract_bs(
     )
 
     if compute_cp_cov:
-        cp_cov = _compute_cp_cov(bs_arr, bs_quantities["bs"], index_mask)
+        cp_cov = _compute_cp_cov(
+            bs_arr, bs_quantities["bs"], index_mask, disable=np.invert(verbose)
+        )
     else:
         cp_cov = None
 

--- a/amical/tests/test_io.py
+++ b/amical/tests/test_io.py
@@ -253,6 +253,29 @@ def test_getPixel(ins):
     assert isinstance(p, float)
 
 
+def test_quiet_mode(global_datadir, capsys):
+    fits_file = global_datadir / "test.fits"
+    with fits.open(fits_file) as fh:
+        cube = fh[0].data
+    bs = amical.extract_bs(
+        cube,
+        fits_file,
+        targetname="test",
+        bs_multi_tri=False,
+        maskname="g7",
+        fw_splodge=0.7,
+        display=False,
+        peakmethod="fft",
+        verbose=False,
+    )
+    captured = capsys.readouterr()
+    bs_keys = list(bs.keys())
+    assert isinstance(bs, munch.Munch)
+    assert len(bs_keys) == 13
+    assert captured.out == ""
+    assert captured.err == ""
+
+
 # @pytest.mark.usefixtures("close_figures")
 # def test_bad_holes(global_datadir):
 #     fits_file = global_datadir / "test.fits"


### PR DESCRIPTION
The kwargs `verbose` = False now suppress the tqdm progress bar (as well as the standard stdout). This feature was requested in #121 and allow to run amical in "quiet mode".