### PR TITLE
filter upstream depr warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,10 @@ filterwarnings = [
     # we run tests against a non-GUI backend on purpose
     "ignore:Matplotlib is currently using agg, which is a non-GUI backend, so cannot show the figure.:UserWarning",
     # astropy regularly ships wheels that violate numpy ABI compatibility, this is out of our control
-    "ignore:numpy.ndarray size changed, may indicate binary incompatibility. Expected \\d\\d from C header, got \\d\\d from PyObject:RuntimeWarning"
+    "ignore:numpy.ndarray size changed, may indicate binary incompatibility. Expected \\d\\d from C header, got \\d\\d from PyObject:RuntimeWarning",
+    #Deprecation warnings emmited from pillow via matplotlib
+    "ignore:NONE is deprecated and will be removed in Pillow 10 \\(2023-07-01\\). Use Resampling.NEAREST or Dither.NONE instead.:DeprecationWarning",
+    "ignore:ADAPTIVE is deprecated and will be removed in Pillow 10 \\(2023-07-01\\). Use Palette.ADAPTIVE instead.:DeprecationWarning",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
fix an instability seen in bleeding-edge CI that we have no control over
see https://github.com/matplotlib/matplotlib/pull/22766 for context