### PR TITLE
Add telescope and instrument to raw oifits

### DIFF
--- a/amical/oifits.py
+++ b/amical/oifits.py
@@ -580,8 +580,8 @@ def save(
     hdu.header["ORIGIN"] = origin or hdr.get("ORIGIN", "Sydney University")
     hdu.header["CONTENT"] = "OIFITS2"
     hdu.header["DATE-OBS"] = hdr.get("date-obs", "")
-    hdu.header["TELESCOP"] = hdr.get("TELESCOP", "")
-    hdu.header["INSTRUME"] = hdr.get("INSTRUME", "")
+    hdu.header["TELESCOP"] = hdr.get("telescop", "")
+    hdu.header["INSTRUME"] = hdr.get("INSTRUME", dic["info"]["INSTRUME"])
     hdu.header["OBSERVER"] = hdr.get("OBSERVER", "")
     hdu.header["OBJECT"] = hdr.get("OBJECT", dic["info"]["TARGET"])
     hdu.header["INSMODE"] = "NRM"

--- a/amical/tests/test_io.py
+++ b/amical/tests/test_io.py
@@ -159,6 +159,7 @@ def test_save_cal(cal, tmpdir):
     assert len(v2) == 21
     assert len(cp) == 35
     assert hdr["ORIGIN"] == "Sydney University"
+    assert hdr["TELESCOP"] == cal.raw_t.infos.telescop
 
 
 def test_save_cal_1hole(cal, tmpdir):


### PR DESCRIPTION
When trying to use AMICAL outputs with [fouriever](https://github.com/kammerje/fouriever), I got an error saying the telescope was unknown. The TELESCOP keyword was an empty string in the oifits even though the initial data had `TELESCOP='JWST'`. The issue seems to be that the telescope is saved in the info dictionary with a lowercase key (like `date-obs`), so it was not found when trying to pass it to the oifits. This fixes the issue by using lowercase. I also added a fallback option for INSTRUME to get the right instrument from the info dict.

I saw that the unit test function for saving raw oifits is commented out, so I did not add a failing test for this.